### PR TITLE
Bypass AWS user data 16kb size limit

### DIFF
--- a/upp-pub-provisioner/DEVELOPER_README.md
+++ b/upp-pub-provisioner/DEVELOPER_README.md
@@ -20,6 +20,9 @@ If you need to add or update etcd keys (or any other environment variables used 
 * [initial_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml)
 * [persistent_instance_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml)
 
+Note that because the provisioned instances download `persistent_instance_user_data.yaml` from GitHub, any local or unpushed changes will NOT be picked up when provisioning.  
+Any changes that you want to test **must** be pushed to a branch before provisioning.
+
 Building
 --------
 

--- a/upp-pub-provisioner/DEVELOPER_README.md
+++ b/upp-pub-provisioner/DEVELOPER_README.md
@@ -1,12 +1,31 @@
 Docker image to provision a cluster
 ===================================
 
+Adding or updating etcd keys
+----------------------------
+
+Due to the 16kb limit on AWS user data, we can no longer pass our full cloud-config to the instances via user data.
+
+To work around this, we now have a smaller [initial_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml), which:
+
+* Stores the provisioning secrets and environment variables on the instance
+* Downloads the [persistent_instance_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml) templates
+* Downloads and runs [substitute-ft-env-variables.sh](https://github.com/Financial-Times/upp-provisioners/blob/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh) to substitute the secrets and environment variables into the template
+* Triggers a second cloud-config run to properly configure the cluster, using the fully expanded template
+
+If you need to add or update etcd keys (or any other environment variables used as part of cloud-config), you must add the variable in 4 locations:
+
+* LastPass, under `TEST Publishing cluster provisioning setup` & `PROD Publishing cluster provisioning setup`
+* [provision.sh](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/provision.sh)
+* [initial_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml)
+* [persistent_instance_user_data.yaml](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml)
+
 Building
 --------
 
 ```bash
 # Build the image
-docker build -t coco/upp-pub-provisioner .
+docker build -t coco/upp-pub-provisioner:local .
 ```
 
 
@@ -19,6 +38,11 @@ Set all the required variables
 ## LastPass: Publishing cluster provisioning setup
 ## For TEST cluster
 ## LastPass: TEST Publishing cluster provisioning setup
+
+## Get the name of the current branch, so that the instances pull the correct user data templates
+## This is only relevant when testing branch changes to the provisioner itself - not required for normal provisioning
+## If not supplied or run while not in a git repo, provision.sh will default to master
+export BRANCH_NAME=`git symbolic-ref HEAD | sed 's|refs/heads/||'`
 
 ## Get a new etcd token for a new cluster, 3 refers to the number of initial boxes in the cluster:
 ## `curl https://discovery.etcd.io/new?size=3`
@@ -150,5 +174,6 @@ docker run \
     -e "ROLES_BERTHA_URL=$ROLES_BERTHA_URL" \
     -e "BRANDS_BERTHA_URL=$BRANDS_BERTHA_URL" \
     -e "MAPPINGS_BERTHA_URL=$MAPPINGS_BERTHA_URL" \
-    coco/upp-pub-provisioner
+    -e "BRANCH_NAME=$BRANCH_NAME" \
+    coco/upp-pub-provisioner:local
 ```

--- a/upp-pub-provisioner/Dockerfile
+++ b/upp-pub-provisioner/Dockerfile
@@ -11,6 +11,7 @@ RUN echo "[localhost]" > ~/.ansible_hosts \
 ADD *.sh /
 ADD cluster-id-extractor /
 ADD ansible/ /ansible
+ADD ../.git/HEAD /git_branch
 
 RUN ln -s /cluster-id-extractor /usr/local/bin/cluster-id-extractor
 

--- a/upp-pub-provisioner/Dockerfile
+++ b/upp-pub-provisioner/Dockerfile
@@ -1,10 +1,5 @@
 FROM alpine
 
-ADD *.sh /
-ADD cluster-id-extractor /
-ADD ansible/ /ansible
-
-RUN ln -s /cluster-id-extractor /usr/local/bin/cluster-id-extractor
 RUN echo "[localhost]" > ~/.ansible_hosts \
  && echo '127.0.0.1 ansible_python_interpreter=/.venv/bin/python' >> ~/.ansible_hosts \
  && apk --update add py-pip py-virtualenv gcc python-dev libffi-dev openssl-dev build-base bash jq util-linux curl \
@@ -12,5 +7,11 @@ RUN echo "[localhost]" > ~/.ansible_hosts \
  && virtualenv .venv \
  && . .venv/bin/activate \
  && pip install ansible==2.0.2.0 boto awscli
+
+ADD *.sh /
+ADD cluster-id-extractor /
+ADD ansible/ /ansible
+
+RUN ln -s /cluster-id-extractor /usr/local/bin/cluster-id-extractor
 
 CMD /bin/bash provision.sh

--- a/upp-pub-provisioner/Dockerfile
+++ b/upp-pub-provisioner/Dockerfile
@@ -11,7 +11,6 @@ RUN echo "[localhost]" > ~/.ansible_hosts \
 ADD *.sh /
 ADD cluster-id-extractor /
 ADD ansible/ /ansible
-ADD ../.git/HEAD /git_branch
 
 RUN ln -s /cluster-id-extractor /usr/local/bin/cluster-id-extractor
 

--- a/upp-pub-provisioner/ansible/aws_coreos_site.yml
+++ b/upp-pub-provisioner/ansible/aws_coreos_site.yml
@@ -143,7 +143,7 @@
         instance_type: "{{instanceType}}"
         wait: true
         exact_count: 1
-        user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
+        user_data: "{{ lookup('template', 'userdata/initial_user_data.yaml') }}"
         vpc_subnet_id: "{{ subnets_id_1 }}"
         assign_public_ip: yes
         volumes:
@@ -181,7 +181,7 @@
         instance_type: "{{instanceType}}"
         wait: true
         exact_count: 1
-        user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
+        user_data: "{{ lookup('template', 'userdata/initial_user_data.yaml') }}"
         vpc_subnet_id: "{{ subnets_id_2 }}"
         assign_public_ip: yes
         volumes:
@@ -219,7 +219,7 @@
         instance_type: "{{instanceType}}"
         wait: true
         exact_count: 1
-        user_data: "{{ lookup('template', 'userdata/persistent_instance_user_data.yaml') }}"
+        user_data: "{{ lookup('template', 'userdata/initial_user_data.yaml') }}"
         vpc_subnet_id: "{{ subnets_id_3 }}"
         assign_public_ip: yes
         volumes:

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -53,7 +53,7 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
         ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -45,6 +45,18 @@ write_files:
 
 coreos:
   units:
+    - name: authorized_keys.service
+      command: start
+      content: |
+          [Unit]
+          Description=Update authorized_keys
+
+          [Service]
+          Type=oneshot
+          ExecStartPre=/bin/sh -c "mkdir -p /home/core/.ssh && touch /home/core/.ssh/authorized_keys"
+          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys.sha512 https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys.sha512"
+          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys"
+          ExecStart=/bin/sh -c "cd /tmp/ && sha512sum -c authorized_keys.sha512 && cp authorized_keys /home/core/.ssh/authorized_keys && chmod 700 /home/core/.ssh && chmod 600 /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh"
     - name: bypass-user-data-limit.service
       command: start
       content: |

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -48,15 +48,15 @@ coreos:
     - name: authorized_keys.service
       command: start
       content: |
-          [Unit]
-          Description=Update authorized_keys
+        [Unit]
+        Description=Update authorized_keys
 
-          [Service]
-          Type=oneshot
-          ExecStartPre=/bin/sh -c "mkdir -p /home/core/.ssh && touch /home/core/.ssh/authorized_keys"
-          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys.sha512 https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys.sha512"
-          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys"
-          ExecStart=/bin/sh -c "cd /tmp/ && sha512sum -c authorized_keys.sha512 && cp authorized_keys /home/core/.ssh/authorized_keys && chmod 700 /home/core/.ssh && chmod 600 /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh"
+        [Service]
+        Type=oneshot
+        ExecStartPre=/bin/sh -c "mkdir -p /home/core/.ssh && touch /home/core/.ssh/authorized_keys"
+        ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys.sha512 https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys.sha512"
+        ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys"
+        ExecStart=/bin/sh -c "cd /tmp/ && sha512sum -c authorized_keys.sha512 && cp authorized_keys /home/core/.ssh/authorized_keys && chmod 700 /home/core/.ssh && chmod 600 /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh"
     - name: bypass-user-data-limit.service
       command: start
       content: |

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -2,7 +2,7 @@
 write_files:
   - path: /tmp/ft-env-variables
     permissions: "0644"
-    owner: "core"
+    owner: "root"
     content: |
       apps_aws_access_key={{apps_aws_access_key}}
       apps_aws_secret_access_key={{apps_aws_secret_access_key}}

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -65,8 +65,8 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
-        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{branch_name}}/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{branch_name}}/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
         ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -1,8 +1,8 @@
 #cloud-config
 write_files:
-  - path: /etc/ft-env-variables
-    permissions: "0755"
-    owner: "root"
+  - path: /tmp/ft-env-variables
+    permissions: "0644"
+    owner: "core"
     content: |
       apps_aws_access_key={{apps_aws_access_key}}
       apps_aws_secret_access_key={{apps_aws_secret_access_key}}
@@ -53,7 +53,11 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        EnvironmentFile=/etc/ft-env-variables
-        ExecStart=/usr/bin/coreos-cloudinit --from-url https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
+        ExecStartPre=/tmp/substitute-ft-env-variables.sh
+        ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml
+        #ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/persistent_instance_user_data.yaml
         RemainAfterExit=yes
         Type=oneshot

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -70,6 +70,6 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
         ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml
-        #ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/persistent_instance_user_data.yaml
+        ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/persistent_instance_user_data.yaml
         RemainAfterExit=yes
         Type=oneshot

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -1,0 +1,15 @@
+#cloud-config
+
+coreos:
+  units:
+    - name: bypass-user-data-limit.service
+      command: start
+      content: |
+        [Unit]
+        Description=Update the machine using our own cloud config, due to 16kb size limit on AWS user data
+
+        [Service]
+        EnvironmentFile=/etc/environment
+        ExecStart=/usr/bin/coreos-cloudinit --from-url https://raw.githubusercontent.com/Financial-Times/upp-provisioners/master/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        RemainAfterExit=yes
+        Type=oneshot

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -1,6 +1,49 @@
 #cloud-config
 
 coreos:
+  write_files:
+    - path: /etc/ft-env-variables
+      permissions: "0755"
+      owner: "root"
+      content: |
+        apps_aws_access_key={{apps_aws_access_key}}
+        apps_aws_secret_access_key={{apps_aws_secret_access_key}}
+        authors_bertha_url={{authors_bertha_url}}
+        binary_s3_bucket={{binary_s3_bucket}}
+        brands_bertha_url={{brands_bertha_url}}
+        brightcove_account_id={{brightcove_account_id}}
+        brightcove_auth={{brightcove_auth}}
+        clusterid={{clusterid}}
+        concepts_rw_s3_bucket={{concepts_rw_s3_bucket}}
+        concepts_rw_s3_bucket_region={{concepts_rw_s3_bucket_region}}
+        delivery_clusters_http_credentials={{delivery_clusters_http_credentials}}
+        delivery_clusters_urls={{delivery_clusters_urls}}
+        environment_tag={{environment_tag}}
+        factset_key_first_part={{factset_key_first_part}}
+        factset_key_second_part={{factset_key_second_part}}
+        factset_username={{factset_username}}
+        konstructor_api_key={{konstructor_api_key}}
+        mappings_bertha_url={{mappings_bertha_url}}
+        pam_credential_validation_uuid={{pam_credential_validation_uuid}}
+        pam_mat_validation_credentials={{pam_mat_validation_credentials}}
+        pam_mat_validation_url={{pam_mat_validation_url}}
+        pam_mcpm_validation_url={{pam_mcpm_validation_url}}
+        persistent_tag={{persistent_tag}}
+        region={{region}}
+        roles_bertha_url={{roles_bertha_url}}
+        s3_image_bucket_urls={{s3_image_bucket_urls}}
+        services_definition_root_uri={{services_definition_root_uri}}
+        synthetic_article_payload={{synthetic_article_payload}}
+        synthetic_article_uuid={{synthetic_article_uuid}}
+        synthetic_list_uuid={{synthetic_list_uuid}}
+        tme_host={{tme_host}}
+        tme_password={{tme_password}}
+        tme_token={{tme_token}}
+        tme_username={{tme_username}}
+        token={{token}}
+        varnish_access_credentials={{varnish_access_credentials}}
+        wordpress_api_key={{wordpress_api_key}}
+        wp_contentApi_key={{wp_contentApi_key}}
   units:
     - name: bypass-user-data-limit.service
       command: start
@@ -10,6 +53,7 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStart=/usr/bin/coreos-cloudinit --from-url https://raw.githubusercontent.com/Financial-Times/upp-provisioners/master/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        EnvironmentFile=/etc/ft-env-variables
+        ExecStart=/usr/bin/coreos-cloudinit --from-url https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         RemainAfterExit=yes
         Type=oneshot

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -1,49 +1,49 @@
 #cloud-config
+write_files:
+  - path: /etc/ft-env-variables
+    permissions: "0755"
+    owner: "root"
+    content: |
+      apps_aws_access_key={{apps_aws_access_key}}
+      apps_aws_secret_access_key={{apps_aws_secret_access_key}}
+      authors_bertha_url={{authors_bertha_url}}
+      binary_s3_bucket={{binary_s3_bucket}}
+      brands_bertha_url={{brands_bertha_url}}
+      brightcove_account_id={{brightcove_account_id}}
+      brightcove_auth={{brightcove_auth}}
+      clusterid={{clusterid}}
+      concepts_rw_s3_bucket={{concepts_rw_s3_bucket}}
+      concepts_rw_s3_bucket_region={{concepts_rw_s3_bucket_region}}
+      delivery_clusters_http_credentials={{delivery_clusters_http_credentials}}
+      delivery_clusters_urls={{delivery_clusters_urls}}
+      environment_tag={{environment_tag}}
+      factset_key_first_part={{factset_key_first_part}}
+      factset_key_second_part={{factset_key_second_part}}
+      factset_username={{factset_username}}
+      konstructor_api_key={{konstructor_api_key}}
+      mappings_bertha_url={{mappings_bertha_url}}
+      pam_credential_validation_uuid={{pam_credential_validation_uuid}}
+      pam_mat_validation_credentials={{pam_mat_validation_credentials}}
+      pam_mat_validation_url={{pam_mat_validation_url}}
+      pam_mcpm_validation_url={{pam_mcpm_validation_url}}
+      persistent_tag={{persistent_tag}}
+      region={{region}}
+      roles_bertha_url={{roles_bertha_url}}
+      s3_image_bucket_urls={{s3_image_bucket_urls}}
+      services_definition_root_uri={{services_definition_root_uri}}
+      synthetic_article_payload={{synthetic_article_payload}}
+      synthetic_article_uuid={{synthetic_article_uuid}}
+      synthetic_list_uuid={{synthetic_list_uuid}}
+      tme_host={{tme_host}}
+      tme_password={{tme_password}}
+      tme_token={{tme_token}}
+      tme_username={{tme_username}}
+      token={{token}}
+      varnish_access_credentials={{varnish_access_credentials}}
+      wordpress_api_key={{wordpress_api_key}}
+      wp_contentApi_key={{wp_contentApi_key}}
 
 coreos:
-  write_files:
-    - path: /etc/ft-env-variables
-      permissions: "0755"
-      owner: "root"
-      content: |
-        apps_aws_access_key={{apps_aws_access_key}}
-        apps_aws_secret_access_key={{apps_aws_secret_access_key}}
-        authors_bertha_url={{authors_bertha_url}}
-        binary_s3_bucket={{binary_s3_bucket}}
-        brands_bertha_url={{brands_bertha_url}}
-        brightcove_account_id={{brightcove_account_id}}
-        brightcove_auth={{brightcove_auth}}
-        clusterid={{clusterid}}
-        concepts_rw_s3_bucket={{concepts_rw_s3_bucket}}
-        concepts_rw_s3_bucket_region={{concepts_rw_s3_bucket_region}}
-        delivery_clusters_http_credentials={{delivery_clusters_http_credentials}}
-        delivery_clusters_urls={{delivery_clusters_urls}}
-        environment_tag={{environment_tag}}
-        factset_key_first_part={{factset_key_first_part}}
-        factset_key_second_part={{factset_key_second_part}}
-        factset_username={{factset_username}}
-        konstructor_api_key={{konstructor_api_key}}
-        mappings_bertha_url={{mappings_bertha_url}}
-        pam_credential_validation_uuid={{pam_credential_validation_uuid}}
-        pam_mat_validation_credentials={{pam_mat_validation_credentials}}
-        pam_mat_validation_url={{pam_mat_validation_url}}
-        pam_mcpm_validation_url={{pam_mcpm_validation_url}}
-        persistent_tag={{persistent_tag}}
-        region={{region}}
-        roles_bertha_url={{roles_bertha_url}}
-        s3_image_bucket_urls={{s3_image_bucket_urls}}
-        services_definition_root_uri={{services_definition_root_uri}}
-        synthetic_article_payload={{synthetic_article_payload}}
-        synthetic_article_uuid={{synthetic_article_uuid}}
-        synthetic_list_uuid={{synthetic_list_uuid}}
-        tme_host={{tme_host}}
-        tme_password={{tme_password}}
-        tme_token={{tme_token}}
-        tme_username={{tme_username}}
-        token={{token}}
-        varnish_access_credentials={{varnish_access_credentials}}
-        wordpress_api_key={{wordpress_api_key}}
-        wp_contentApi_key={{wp_contentApi_key}}
   units:
     - name: bypass-user-data-limit.service
       command: start

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -65,8 +65,8 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{git_branch}}/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
-        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{git_branch}}/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
         ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -65,8 +65,8 @@ coreos:
 
         [Service]
         EnvironmentFile=/etc/environment
-        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
-        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/upp-pub-provisioner/userdata-size-reduction/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{git_branch}}/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{git_branch}}/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
         ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -4,7 +4,7 @@ coreos:
   update:
     reboot-strategy: off
   etcd2:
-    discovery: {{token}}
+    discovery: $token
     heartbeat-interval: 300
     election-timeout: 3000
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001
@@ -13,7 +13,7 @@ coreos:
     listen-peer-urls: http://$private_ipv4:2380,http://$private_ipv4:7001
   fleet:
     etcd_request_timeout: 3.0
-    metadata: host_type=persistent,persistent_tag={{persistent_tag}}
+    metadata: host_type=persistent,persistent_tag=$persistent_tag
   units:
     - name: update-engine.service
       command: stop
@@ -65,44 +65,44 @@ coreos:
           [Service]
           Type=oneshot
           ExecStartPre=/bin/sh -c "while true; do etcdctl cluster-health && break || sleep 2; done"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/aws/aws_access_key_id '{{ apps_aws_access_key }}'                                   >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/aws/aws_secret_access_key '{{ apps_aws_secret_access_key }}'                        >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/brightcove_auth '{{brightcove_auth}}'                                               >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/cms-notifier/post-credentials '{{ cms_notifier_credentials }}'                      >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/elb_name 'coreos-up-{{clusterid}}'                                                  >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/varnish/htpasswd '{{ varnish_access_credentials }}'                                 >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/konstructor/api-key '{{ konstructor_api_key }}'                                     >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/wordpress/content_api_key '{{ wordpress_api_key }}'                                 >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/wp '{{ wp_contentApi_key }}'                                                        >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/username '{{ tme_username }}'                                                   >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/password '{{ tme_password }}'                                                   >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/token '{{ tme_token }}'                                                         >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/environment_tag '{{environment_tag}}'                                                     >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/aws_region '{{region}}'                                                                   >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/aws/aws_access_key_id '$apps_aws_access_key'                                   >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/aws/aws_secret_access_key '$apps_aws_secret_access_key'                        >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/brightcove_auth '$brightcove_auth'                                               >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/cms-notifier/post-credentials '$cms_notifier_credentials'                      >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/elb_name 'coreos-up-$clusterid'                                                  >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/varnish/htpasswd '$varnish_access_credentials'                                 >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/konstructor/api-key '$konstructor_api_key'                                     >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/wordpress/content_api_key '$wordpress_api_key'                                 >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/wp '$wp_contentApi_key'                                                        >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/username '$tme_username'                                                   >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/password '$tme_password'                                                   >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/tme/token '$tme_token'                                                         >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/environment_tag '$environment_tag'                                                     >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/aws_region '$region'                                                                   >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/splunk-forwarder/splunk_url 'https://ingest.splunk.glb.ft.com/coco-up/fleet'              >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/concepts-rw-s3/bucket '{{concepts_rw_s3_bucket}}'                                         >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/concepts-rw-s3/bucket_region '{{concepts_rw_s3_bucket_region}}'                           >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/services-definition-root-uri '{{services_definition_root_uri}}'                           >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/authors '{{authors_bertha_url}}'                                              >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/roles '{{roles_bertha_url}}'                                                  >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/brands '{{brands_bertha_url}}'                                                >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/video-metadata-mappings '{{mappings_bertha_url}}'                             >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/tme_host '{{tme_host}}'                                                                   >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/brightcove/account-id '{{brightcove_account_id}}'                                         >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/read-urls '{{delivery_clusters_urls}}'                                         >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/s3-image-bucket-urls '{{s3_image_bucket_urls}}'                                >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/binary-s3-bucket '{{binary_s3_bucket}}'                                        >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-mat-validation-url '{{pam_mat_validation_url}}'                            >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-mcpm-validation-url '{{pam_mcpm_validation_url}}'                          >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-credential-validation-uuid '{{pam_credential_validation_uuid}}'            >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-article-uuid '{{synthetic_article_uuid}}'                            >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-article-payload '{{synthetic_article_payload}}'                      >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-list-uuid '{{synthetic_list_uuid}}'                                  >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/publish-read/read-credentials '{{delivery_clusters_http_credentials}}'              >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/publish-read/validator-credentials '{{pam_mat_validation_credentials}}'             >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/username '{{ factset_username }}'                                           >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/first_part '{{ factset_key_first_part }}'                               >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/second_part '{{ factset_key_second_part }}'                             >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/concepts-rw-s3/bucket '$concepts_rw_s3_bucket'                                         >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/concepts-rw-s3/bucket_region '$concepts_rw_s3_bucket_region'                           >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/services-definition-root-uri '$services_definition_root_uri'                           >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/authors '$authors_bertha_url'                                              >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/roles '$roles_bertha_url'                                                  >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/brands '$brands_bertha_url'                                                >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/bertha/urls/video-metadata-mappings '$mappings_bertha_url'                             >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/tme_host '$tme_host'                                                                   >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/brightcove/account-id '$brightcove_account_id'                                         >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/read-urls '$delivery_clusters_urls'                                         >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/s3-image-bucket-urls '$s3_image_bucket_urls'                                >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/binary-s3-bucket '$binary_s3_bucket'                                        >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-mat-validation-url '$pam_mat_validation_url'                            >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-mcpm-validation-url '$pam_mcpm_validation_url'                          >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/pam-credential-validation-uuid '$pam_credential_validation_uuid'            >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-article-uuid '$synthetic_article_uuid'                            >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-article-payload '$synthetic_article_payload'                      >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/monitoring/synthetic-list-uuid '$synthetic_list_uuid'                                  >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/publish-read/read-credentials '$delivery_clusters_http_credentials'              >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/publish-read/validator-credentials '$pam_mat_validation_credentials'             >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/username '$factset_username'                                           >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/first_part '$factset_key_first_part'                               >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/second_part '$factset_key_second_part'                             >/dev/null 2>&1 || true;"
 
     - name: bootstrap.service
       command: start
@@ -141,7 +141,7 @@ write_files:
       ListenStream=0.0.0.0:49153
   - path: /etc/motd.d/env.conf
     content: |
-            This enviroment is tagged as {{environment_tag}} and is cluster {{token}}
+            This enviroment is tagged as $environment_tag and is cluster $token
   - path: /home/core/.toolboxrc
     owner: core
     content: |
@@ -205,3 +205,9 @@ write_files:
         ForwardAgent yes
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
+  # empty the ft-env-variables file once we're done with our cloud-config run
+  - path: "/etc/ft-env-variables"
+    - path: /etc/ft-env-variables
+      permissions: "0755"
+      owner: "root"
+      content: |

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -207,7 +207,6 @@ write_files:
         UserKnownHostsFile /dev/null
   # empty the ft-env-variables file once we're done with our cloud-config run
   - path: "/etc/ft-env-variables"
-    - path: /etc/ft-env-variables
-      permissions: "0755"
-      owner: "root"
-      content: |
+    permissions: "0755"
+    owner: "root"
+    content: |

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -205,8 +205,8 @@ write_files:
         ForwardAgent yes
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
-  # empty the ft-env-variables file once we're done with our cloud-config run
-  - path: "/etc/ft-env-variables"
-    permissions: "0755"
-    owner: "root"
-    content: |
+  # # empty the ft-env-variables file once we're done with our cloud-config run
+  # - path: "/etc/ft-env-variables"
+  #   permissions: "0755"
+  #   owner: "root"
+  #   content: |

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -4,7 +4,7 @@ coreos:
   update:
     reboot-strategy: off
   etcd2:
-    discovery: $token
+    discovery: ${token}
     heartbeat-interval: 300
     election-timeout: 3000
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -4,7 +4,7 @@ coreos:
   update:
     reboot-strategy: off
   etcd2:
-    discovery: ${token}
+    discovery: $token
     heartbeat-interval: 300
     election-timeout: 3000
     advertise-client-urls: http://$private_ipv4:2379,http://$private_ipv4:4001

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -20,18 +20,6 @@ coreos:
       mask: true
     - name: locksmithd.service
       command: stop
-    - name: authorized_keys.service
-      command: start
-      content: |
-          [Unit]
-          Description=Update authorized_keys
-
-          [Service]
-          Type=oneshot
-          ExecStartPre=/bin/sh -c "mkdir -p /home/core/.ssh && touch /home/core/.ssh/authorized_keys"
-          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys.sha512 https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys.sha512"
-          ExecStart=/bin/sh -c "curl -sSL --retry 5 --retry-delay 2 -o /tmp/authorized_keys https://raw.githubusercontent.com/Financial-Times/up-ssh-keys/master/authorized_keys"
-          ExecStart=/bin/sh -c "cd /tmp/ && sha512sum -c authorized_keys.sha512 && cp authorized_keys /home/core/.ssh/authorized_keys && chmod 700 /home/core/.ssh && chmod 600 /home/core/.ssh/authorized_keys && chown -R core:core /home/core/.ssh"
     - name: authorized_keys.timer
       command: start
       content: |

--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -205,8 +205,3 @@ write_files:
         ForwardAgent yes
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
-  # # empty the ft-env-variables file once we're done with our cloud-config run
-  # - path: "/etc/ft-env-variables"
-  #   permissions: "0755"
-  #   owner: "root"
-  #   content: |

--- a/upp-pub-provisioner/provision.sh
+++ b/upp-pub-provisioner/provision.sh
@@ -20,7 +20,7 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   region=$AWS_DEFAULT_REGION \
   token=$TOKEN_URL \
   services_definition_root_uri=${SERVICES_DEFINITION_ROOT_URI:=https://raw.githubusercontent.com/Financial-Times/pub-service-files/master/} \
-  aws_access_key_id=$AWS_ACCESS_KEY_ID \ 
+  aws_access_key_id=$AWS_ACCESS_KEY_ID \
   aws_secret_access_key=$AWS_SECRET_ACCESS_KEY \
   binary_writer_bucket=$BINARY_WRITER_BUCKET \
   concepts_rw_s3_bucket=$CONCEPTS_RW_S3_BUCKET \
@@ -30,8 +30,8 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
   varnish_access_credentials=${CLUSTER_BASIC_HTTP_CREDENTIALS} \
   authors_bertha_url=${AUTHORS_BERTHA_URL} \
-  roles_bertha_url=${ROLES_BERTHA_URL} \	  	  
-  brands_bertha_url=${BRANDS_BERTHA_URL} \	  	  
+  roles_bertha_url=${ROLES_BERTHA_URL} \
+  brands_bertha_url=${BRANDS_BERTHA_URL} \
   mappings_bertha_url=${MAPPINGS_BERTHA_URL} \
   environment_tag=${ENVIRONMENT_TAG:=default} \
   environment_type=${ENVIRONMENT_TYPE:=p} \
@@ -48,5 +48,6 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   pam_credential_validation_uuid=${PAM_CREDENTIAL_VALIDATION_UUID} \
   synthetic_article_uuid=${SYNTHETIC_ARTICLE_UUID} \
   synthetic_article_payload=${SYNTHETIC_ARTICLE_PAYLOAD:=/com/ft/syntheticpublicationmonitor/templates/article-payload.json} \
-  synthetic_list_uuid=${SYNTHETIC_LIST_UUID}" \
+  synthetic_list_uuid=${SYNTHETIC_LIST_UUID} \
+  branch_name=${BRANCH_NAME:=master}" \
   --vault-password-file=/vault.pass

--- a/upp-pub-provisioner/provision.sh
+++ b/upp-pub-provisioner/provision.sh
@@ -12,7 +12,6 @@ if [ -z "$COCO_MONITOR_TEST_UUID" ]; then COCO_MONITOR_TEST_UUID=$(uuidgen); fi
 CLUSTERID=`echo $TOKEN_URL | sed "s/http.*\///g" | cut -c1-8`
 AMI=`curl -s https://coreos.com/dist/aws/aws-stable.json | jq --arg region $AWS_DEFAULT_REGION -r '.[$region].hvm'`
 ZONES=(`aws ec2 describe-availability-zones --region $AWS_DEFAULT_REGION | jq -r '.AvailabilityZones[].ZoneName'`)
-GIT_BRANCH=`sed 's|ref: refs/heads/||' /git_branch`
 
 echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/aws_coreos_site.yml --extra-vars " \
   clusterid=$CLUSTERID \
@@ -21,7 +20,7 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   region=$AWS_DEFAULT_REGION \
   token=$TOKEN_URL \
   services_definition_root_uri=${SERVICES_DEFINITION_ROOT_URI:=https://raw.githubusercontent.com/Financial-Times/pub-service-files/master/} \
-  aws_access_key_id=$AWS_ACCESS_KEY_ID \
+  aws_access_key_id=$AWS_ACCESS_KEY_ID \ 
   aws_secret_access_key=$AWS_SECRET_ACCESS_KEY \
   binary_writer_bucket=$BINARY_WRITER_BUCKET \
   concepts_rw_s3_bucket=$CONCEPTS_RW_S3_BUCKET \
@@ -31,8 +30,8 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
   varnish_access_credentials=${CLUSTER_BASIC_HTTP_CREDENTIALS} \
   authors_bertha_url=${AUTHORS_BERTHA_URL} \
-  roles_bertha_url=${ROLES_BERTHA_URL} \
-  brands_bertha_url=${BRANDS_BERTHA_URL} \
+  roles_bertha_url=${ROLES_BERTHA_URL} \	  	  
+  brands_bertha_url=${BRANDS_BERTHA_URL} \	  	  
   mappings_bertha_url=${MAPPINGS_BERTHA_URL} \
   environment_tag=${ENVIRONMENT_TAG:=default} \
   environment_type=${ENVIRONMENT_TYPE:=p} \
@@ -49,6 +48,5 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   pam_credential_validation_uuid=${PAM_CREDENTIAL_VALIDATION_UUID} \
   synthetic_article_uuid=${SYNTHETIC_ARTICLE_UUID} \
   synthetic_article_payload=${SYNTHETIC_ARTICLE_PAYLOAD:=/com/ft/syntheticpublicationmonitor/templates/article-payload.json} \
-  synthetic_list_uuid=${SYNTHETIC_LIST_UUID} \
-  git_branch=${GIT_BRANCH}" \
+  synthetic_list_uuid=${SYNTHETIC_LIST_UUID}" \
   --vault-password-file=/vault.pass

--- a/upp-pub-provisioner/provision.sh
+++ b/upp-pub-provisioner/provision.sh
@@ -12,6 +12,7 @@ if [ -z "$COCO_MONITOR_TEST_UUID" ]; then COCO_MONITOR_TEST_UUID=$(uuidgen); fi
 CLUSTERID=`echo $TOKEN_URL | sed "s/http.*\///g" | cut -c1-8`
 AMI=`curl -s https://coreos.com/dist/aws/aws-stable.json | jq --arg region $AWS_DEFAULT_REGION -r '.[$region].hvm'`
 ZONES=(`aws ec2 describe-availability-zones --region $AWS_DEFAULT_REGION | jq -r '.AvailabilityZones[].ZoneName'`)
+GIT_BRANCH=`sed 's|ref: refs/heads/||' /git_branch`
 
 echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/aws_coreos_site.yml --extra-vars " \
   clusterid=$CLUSTERID \
@@ -20,7 +21,7 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   region=$AWS_DEFAULT_REGION \
   token=$TOKEN_URL \
   services_definition_root_uri=${SERVICES_DEFINITION_ROOT_URI:=https://raw.githubusercontent.com/Financial-Times/pub-service-files/master/} \
-  aws_access_key_id=$AWS_ACCESS_KEY_ID \ 
+  aws_access_key_id=$AWS_ACCESS_KEY_ID \
   aws_secret_access_key=$AWS_SECRET_ACCESS_KEY \
   binary_writer_bucket=$BINARY_WRITER_BUCKET \
   concepts_rw_s3_bucket=$CONCEPTS_RW_S3_BUCKET \
@@ -30,8 +31,8 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   bridging_message_queue_proxy=${BRIDGING_MESSAGE_QUEUE_PROXY:=https://kafka-proxy-iw-uk-p-1.glb.ft.com,https://kafka-proxy-iw-uk-p-2.glb.ft.com} \
   varnish_access_credentials=${CLUSTER_BASIC_HTTP_CREDENTIALS} \
   authors_bertha_url=${AUTHORS_BERTHA_URL} \
-  roles_bertha_url=${ROLES_BERTHA_URL} \	  	  
-  brands_bertha_url=${BRANDS_BERTHA_URL} \	  	  
+  roles_bertha_url=${ROLES_BERTHA_URL} \
+  brands_bertha_url=${BRANDS_BERTHA_URL} \
   mappings_bertha_url=${MAPPINGS_BERTHA_URL} \
   environment_tag=${ENVIRONMENT_TAG:=default} \
   environment_type=${ENVIRONMENT_TYPE:=p} \
@@ -48,5 +49,6 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   pam_credential_validation_uuid=${PAM_CREDENTIAL_VALIDATION_UUID} \
   synthetic_article_uuid=${SYNTHETIC_ARTICLE_UUID} \
   synthetic_article_payload=${SYNTHETIC_ARTICLE_PAYLOAD:=/com/ft/syntheticpublicationmonitor/templates/article-payload.json} \
-  synthetic_list_uuid=${SYNTHETIC_LIST_UUID}" \
+  synthetic_list_uuid=${SYNTHETIC_LIST_UUID} \
+  git_branch=${GIT_BRANCH}" \
   --vault-password-file=/vault.pass

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -7,5 +7,5 @@ for variable in `cat /tmp/ft-env-variables` ; do
     key=${variable%=*}
     value=${variable##*=}
 
-    sed -i "s/\$${key}/${value}/g" /tmp/ft-env-variables
+    sed -i "s|\$${key}|${value}|g" /tmp/ft-env-variables
 done

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -7,5 +7,5 @@ for variable in `cat /tmp/ft-env-variables` ; do
     key=${variable%=*}
     value=${variable##*=}
 
-    sed -i "s|\$${key}|${value}|g" /tmp/ft-env-variables
+    sed -i "s\|\$${key}|${value}|g" /tmp/ft-env-variables
 done

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -7,5 +7,5 @@ for variable in `cat /tmp/ft-env-variables` ; do
     key=${variable%=*}
     value=${variable##*=}
 
-    sed -i "s|\$${key}|${value}|g" /tmp/ft-env-variables
+    sed -i "s|\$${key}|${value}|g" /tmp/persistent_instance_user_data.yaml
 done

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -1,4 +1,4 @@
-#/!bin/bash
+#!/bin/bash
 
 for variable in `cat /tmp/ft-env-variables` ; do
     # this splits the key value pairs into two separate variables

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -1,0 +1,11 @@
+#/!bin/bash
+
+for variable in `cat /tmp/ft-env-variables` ; do
+    # this splits the key value pairs into two separate variables
+    # for more info on how it works:
+    # http://stackoverflow.com/a/19482947
+    key=${variable%=*}
+    value=${variable##*=}
+
+    sed -i "s/\$${key}/${value}/g" /tmp/ft-env-variables
+done

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -7,5 +7,5 @@ for variable in `cat /tmp/ft-env-variables` ; do
     key=${variable%=*}
     value=${variable##*=}
 
-    sed -i "s\|\$${key}|${value}|g" /tmp/ft-env-variables
+    sed -i "s|\$${key}|${value}|g" /tmp/ft-env-variables
 done


### PR DESCRIPTION
We're currently running into issues with our cloud-config user data, as once all the variables are substituted, we hit the AWS 16kb limit and the cluster fails to provision.

This PR uses a smaller initialization cloud-config which downloads our full cloud-config template from GitHub, substitutes the appropriate environment variables, then triggers a second cloud-init run with the full cloud-config to provision the cluster.