### PR TITLE
Re-add swap service to upp-pub-provisioner user data

### DIFF
--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -39,6 +39,27 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-driver=none --host 0.0.0.0:2375"
       command: start
+    - name: swapon.service
+      command: stop
+      content: |
+          [Unit]
+          Description=Create swap
+
+          [Service]
+          Type=oneshot
+          Environment="SWAPFILE=/swapfile"
+          RemainAfterExit=true
+          ExecStartPre=/usr/bin/touch ${SWAPFILE}
+          ExecStartPre=/usr/bin/fallocate -l 4096m ${SWAPFILE}
+          ExecStartPre=/usr/bin/chmod 600 ${SWAPFILE}
+          ExecStartPre=/usr/sbin/mkswap ${SWAPFILE}
+          ExecStartPre=/usr/sbin/losetup -f ${SWAPFILE}
+          ExecStart=/usr/bin/sh -c "/sbin/swapon $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
+          ExecStop=/usr/bin/sh -c "/sbin/swapoff $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
+          ExecStopPost=/usr/bin/sh -c "/usr/sbin/losetup -d $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
+
+          [Install]
+          WantedBy=multi-user.target
     - name: etcd2.service
       command: start
     - name: fleet.service


### PR DESCRIPTION
Was originally removed as a workaround because we were hitting the 16kb limit on AWS user data.

The full workaround changes are now in master, so we can add this service back in again.