### PR TITLE
Remove swap service from upp-delivery-provisioner

### DIFF
--- a/upp-delivery-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -43,27 +43,6 @@ coreos:
           content: |
             [Service]
             Environment="DOCKER_OPTS=--log-driver=none --host 0.0.0.0:2375"
-    - name: swapon.service
-      command: stop
-      content: |
-          [Unit]
-          Description=Create swap
-
-          [Service]
-          Type=oneshot
-          Environment="SWAPFILE=/swapfile"
-          RemainAfterExit=true
-          ExecStartPre=/usr/bin/touch ${SWAPFILE}
-          ExecStartPre=/usr/bin/fallocate -l 4096m ${SWAPFILE}
-          ExecStartPre=/usr/bin/chmod 600 ${SWAPFILE}
-          ExecStartPre=/usr/sbin/mkswap ${SWAPFILE}
-          ExecStartPre=/usr/sbin/losetup -f ${SWAPFILE}
-          ExecStart=/usr/bin/sh -c "/sbin/swapon $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-          ExecStop=/usr/bin/sh -c "/sbin/swapoff $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-          ExecStopPost=/usr/bin/sh -c "/usr/sbin/losetup -d $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-
-          [Install]
-          WantedBy=multi-user.target
     - name: etcd2.service
       command: start
     - name: fleet.service

--- a/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
@@ -42,27 +42,6 @@ coreos:
             [Service]
             Environment="DOCKER_OPTS=--log-driver=none"
       command: start
-    - name: swapon.service
-      command: stop
-      content: |
-          [Unit]
-          Description=Create swap
-
-          [Service]
-          Type=oneshot
-          Environment="SWAPFILE=/swapfile"
-          RemainAfterExit=true
-          ExecStartPre=/usr/bin/touch ${SWAPFILE}
-          ExecStartPre=/usr/bin/fallocate -l 4096m ${SWAPFILE}
-          ExecStartPre=/usr/bin/chmod 600 ${SWAPFILE}
-          ExecStartPre=/usr/sbin/mkswap ${SWAPFILE}
-          ExecStartPre=/usr/sbin/losetup -f ${SWAPFILE}
-          ExecStart=/usr/bin/sh -c "/sbin/swapon $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-          ExecStop=/usr/bin/sh -c "/sbin/swapoff $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-          ExecStopPost=/usr/bin/sh -c "/usr/sbin/losetup -d $(/usr/sbin/losetup -j ${SWAPFILE} | /usr/bin/cut -d : -f 1)"
-
-          [Install]
-          WantedBy=multi-user.target
     - name: etcd2.service
       command: start
     - name: fleet.service


### PR DESCRIPTION
There's no real reason we would want to re-enable swap on any of our clusters - and even if we did, it's trivial to do it manually.

The custom `swapon.service` has been removed from `upp-pub-provisioner` already, this PR removes it from the delivery provisioner as well.