### PR TITLE
Whitelist Park Royal IP address

### DIFF
--- a/upp-delivery-provisioner/ansible/aws_coreos_site.yml
+++ b/upp-delivery-provisioner/ansible/aws_coreos_site.yml
@@ -35,6 +35,11 @@
             from_port: 22
             to_port: 22
             cidr_ip: 82.136.1.214/32
+          # Park Royal
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 213.216.148.1/32
           # XP - Cluj office
           - proto: tcp
             from_port: 22

--- a/upp-elasticsearch-provisioner/cloudformation/upp-concepts.yml
+++ b/upp-elasticsearch-provisioner/cloudformation/upp-concepts.yml
@@ -47,6 +47,8 @@ Resources:
                 aws:SourceIP:
                   # OSB + LDNWebPerf
                   - "82.136.1.214/32"
+                  # Park Royal
+                  - "213.216.148.1/32"
                   # iQuest - Cluj office
                   - "194.117.242.0/23"
                   # EU VPN Client

--- a/upp-elasticsearch-provisioner/cloudformation/upp-sapi-v1.yml
+++ b/upp-elasticsearch-provisioner/cloudformation/upp-sapi-v1.yml
@@ -48,6 +48,8 @@ Resources:
                 aws:SourceIP:
                   # OSB + LDNWebPerf
                   - "82.136.1.214/32"
+                  # Park Royal
+                  - "213.216.148.1/32"
                   # iQuest - Cluj office
                   - "194.117.242.0/23"
                   # EU VPN Client

--- a/upp-neo4j-provisioner/cloudformation/jumpbox.yaml
+++ b/upp-neo4j-provisioner/cloudformation/jumpbox.yaml
@@ -176,6 +176,11 @@ Resources:
         FromPort: 22
         ToPort: 22
         CidrIp: 82.136.1.214/32
+      # Park Royal
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: 213.216.148.1/32
       # XP - Cluj Office
       - IpProtocol: tcp
         FromPort: 22

--- a/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
+++ b/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
@@ -211,6 +211,11 @@ Resources:
         FromPort: 22
         ToPort: 22
         CidrIp: 82.136.1.214/32
+      # Park Royal
+      - IpProtocol: tcp
+        FromPort: 22
+        ToPort: 22
+        CidrIp: 213.216.148.1/32
       # XP - Cluj Office
       - IpProtocol: tcp
         FromPort: 22

--- a/upp-pub-provisioner/ansible/aws_coreos_site.yml
+++ b/upp-pub-provisioner/ansible/aws_coreos_site.yml
@@ -35,6 +35,11 @@
             from_port: 22
             to_port: 22
             cidr_ip: 82.136.1.214/32
+          # Park Royal
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: 213.216.148.1/32
           # XP - Cluj office
           - proto: tcp
             from_port: 22


### PR DESCRIPTION
Previously we only whitelisted the Watford IP address for SSH access to our clusters - our internet connection was failed over at the weekend, causing us to lose SSH connectivity.

This change whitelists SSH connections coming from both IW and PR for all of our various cluster types.