### PR TITLE
Fix userdata variable substitution

### DIFF
--- a/upp-delivery-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-delivery-provisioner/sh/substitute-ft-env-variables.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-for variable in `cat /tmp/ft-env-variables` ; do
+while read variable ; do
     # this splits the key value pairs into two separate variables
     # for more info on how it works:
-    # http://stackoverflow.com/a/19482947
-    key=${variable%=*}
-    value=${variable##*=}
+    # https://stackoverflow.com/a/1521498
+    # https://unix.stackexchange.com/a/53315
+    key=$(cut -d '=' -f 1 <<< "$variable")
+    value=$(cut -d '=' -f 2- <<< "$variable")
 
-    sed -i "s|\$${key}|${value}|g" /tmp/instance_user_data.yaml
-done
+    sed -i "s|'\$${key}'|'${value}'|g" /tmp/instance_user_data.yaml
+done < /tmp/ft-env-variables

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -70,10 +70,10 @@ coreos:
         [Service]
         EnvironmentFile=/etc/environment
         ExecStartPre=/usr/bin/wget -qO /tmp/substitute-ft-env-variables.sh https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{branch_name}}/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
-        ExecStartPre=/usr/bin/wget -qO /tmp/persistent_instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{branch_name}}/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+        ExecStartPre=/usr/bin/wget -qO /tmp/instance_user_data.yaml https://raw.githubusercontent.com/Financial-Times/upp-provisioners/{{branch_name}}/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
-        ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/persistent_instance_user_data.yaml
-        ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/persistent_instance_user_data.yaml
+        ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/instance_user_data.yaml
+        ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/sinstance_user_data.yaml
         RemainAfterExit=yes
         Type=oneshot

--- a/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/initial_user_data.yaml
@@ -74,6 +74,6 @@ coreos:
         ExecStartPre=/usr/bin/chmod +x /tmp/substitute-ft-env-variables.sh
         ExecStartPre=/tmp/substitute-ft-env-variables.sh
         ExecStart=/usr/bin/coreos-cloudinit --from-file /tmp/instance_user_data.yaml
-        ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/sinstance_user_data.yaml
+        ExecStartPost=/usr/bin/rm /tmp/ft-env-variables /tmp/substitute-ft-env-variables.sh /tmp/instance_user_data.yaml
         RemainAfterExit=yes
         Type=oneshot

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-for variable in `cat /tmp/ft-env-variables` ; do
+while read variable ; do
     # this splits the key value pairs into two separate variables
     # for more info on how it works:
+    # https://stackoverflow.com/a/1521498
     # https://unix.stackexchange.com/a/53315
-    IFS='=' read -r key value <<< "$variable"
+    key=$(cut -d '=' -f 1 <<< "$variable")
+    value=$(cut -d '=' -f 2- <<< "$variable")
 
-    sed -i "s|\$${key}|${value}|g" /tmp/persistent_instance_user_data.yaml
-done
+    sed -i "s|'\$${key}'|'${value}'|g" /tmp/persistent_instance_user_data.yaml
+done < /tmp/ft-env-variables

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -3,9 +3,8 @@
 for variable in `cat /tmp/ft-env-variables` ; do
     # this splits the key value pairs into two separate variables
     # for more info on how it works:
-    # http://stackoverflow.com/a/19482947
-    key=${variable%=*}
-    value=${variable##*=}
+    # https://unix.stackexchange.com/a/53315
+    IFS='=' read -r key value <<< "$variable"
 
     sed -i "s|\$${key}|${value}|g" /tmp/persistent_instance_user_data.yaml
 done

--- a/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
+++ b/upp-pub-provisioner/sh/substitute-ft-env-variables.sh
@@ -8,5 +8,5 @@ while read variable ; do
     key=$(cut -d '=' -f 1 <<< "$variable")
     value=$(cut -d '=' -f 2- <<< "$variable")
 
-    sed -i "s|'\$${key}'|'${value}'|g" /tmp/persistent_instance_user_data.yaml
+    sed -i "s|'\$${key}'|'${value}'|g" /tmp/instance_user_data.yaml
 done < /tmp/ft-env-variables


### PR DESCRIPTION
Previously, the script was failing to properly substitute userdata variables when...
- the value contained a space
- the value contained an equals symbol
- a part of a key name was used for another key (eg, `queue-proxy` and `queue-proxy-auth-key`)

This PR fixes the above issues, as well as making the temp file location consistent across both delivery and publishing clusters.