### PR TITLE
Adding publishing healthcheck key with default value of false

### DIFF
--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -95,6 +95,7 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/username '$factset_username'                                           >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/first_part '$factset_key_first_part'                               >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/second_part '$factset_key_second_part'                             >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/healthcheck-categories/publish/enabled 'false'                                              >/dev/null 2>&1 || true;"
 
     - name: bootstrap.service
       command: start


### PR DESCRIPTION
Publish carousel expects the `/ft/healthcheck-categories/publish/enabled` key to exist, otherwise it fails to start.

I also think it's generally good practice for provisioned clusters to automatically have the keys we expect, rather than  having to go in  and add them in ourselves manually.

This PR adds the key with  a default value of `false` - we can then manually enable a newly provisioned cluster once we're happy that it's healthy and ready to accept publishes.