### PR TITLE
Adding neo4j fleet endpoint etcd key

### DIFF
--- a/upp-delivery-provisioner/DEVELOPER_README.md
+++ b/upp-delivery-provisioner/DEVELOPER_README.md
@@ -128,6 +128,9 @@ export METHODE_API=
 ## The read and write URLs to connect to your cluster's Neo4j database.
 export NEO4J_READ_URL=
 export NEO4J_WRITE_URL=
+
+## Neo4j Fleet Endpoint URL
+export NEO4J_FLEET_ENDPOINT=
 ```
 
 

--- a/upp-delivery-provisioner/README.md
+++ b/upp-delivery-provisioner/README.md
@@ -66,6 +66,7 @@ docker run \
     -e "AWS_ES_ENDPOINT=$AWS_ES_ENDPOINT" \
     -e "AWS_ES_CONTENT_ENDPOINT=$AWS_ES_CONTENT_ENDPOINT" \
     -e "METHODE_API=$METHODE_API" \
+    -e "NEO4J_FLEET_ENDPOINT=$NEO4J_FLEET_ENDPOINT" \
     coco/upp-delivery-provisioner:latest
 
 ## Note - if you require a specific version of the docker image, you can replace 'latest' with 'v1.0.17'

--- a/upp-delivery-provisioner/ansible/userdata/initial_stateless_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/initial_stateless_user_data.yaml
@@ -25,6 +25,7 @@ write_files:
       metadata_services_username={{metadata_services_username}}
       methode_api={{methode_api}}
       methode_api_proxy_authorization_key={{methode_api_proxy_authorization_key}}
+      neo4j_fleet_endpoint={{neo4j_fleet_endpoint}}
       neo4j_read_url={{neo4j_read_url}}
       neo4j_write_url={{neo4j_write_url}}
       pub_pre_prod_credentials={{pub_pre_prod_credentials}}

--- a/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
@@ -100,6 +100,7 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/methode-api '$methode_api'                                                             >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/neo4j/read_only_url '$neo4j_read_url'                                                  >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/neo4j/read_write_url '$neo4j_write_url'                                                >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/neo4j/fleet_endpoint '$neo4j_fleet_endpoint'                                           >/dev/null 2>&1 || true;"
     - name: bootstrap.service
       command: start
       content: |

--- a/upp-delivery-provisioner/provision.sh
+++ b/upp-delivery-provisioner/provision.sh
@@ -42,5 +42,6 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   aws_es_endpoint=${AWS_ES_ENDPOINT} \
   aws_es_content_endpoint=${AWS_ES_CONTENT_ENDPOINT} \
   methode_api=${METHODE_API} \
+  neo4j_fleet_endpoint=${NEO4J_FLEET_ENDPOINT} \
   branch_name=${BRANCH_NAME:=master}" \
   --vault-password-file=/vault.pass


### PR DESCRIPTION
fleet-neo4j-unit-healthcheck was failing to start at provision time because it expected the `/ft/config/neo4j/fleet_endpoint` key to exist.

This PR creates that key at provision time.

Default values added to LastPass.