### PR TITLE
Revert "Adding publishing healthcheck key with default value of false"

### DIFF
--- a/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
+++ b/upp-pub-provisioner/ansible/userdata/persistent_instance_user_data.yaml
@@ -95,7 +95,6 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/username '$factset_username'                                           >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/first_part '$factset_key_first_part'                               >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/factset/key/second_part '$factset_key_second_part'                             >/dev/null 2>&1 || true;"
-          ExecStart=/bin/sh -c "etcdctl mk /ft/healthcheck-categories/publish/enabled 'false'                                              >/dev/null 2>&1 || true;"
 
     - name: bootstrap.service
       command: start


### PR DESCRIPTION
Reverts Financial-Times/upp-provisioners#51

etcd2 currently failing to start at provision time - will reapply each PR one at a time to work out what's breaking it.