### PR TITLE
Update neo4j data snapshot

### DIFF
--- a/upp-neo4j-provisioner/Dockerfile
+++ b/upp-neo4j-provisioner/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.5
 
+RUN apk --update add bash curl py-pip jq \
+    && pip install --upgrade pip awscli
+
 COPY provision.sh /provision.sh
 COPY decom.sh /decom.sh
 COPY cloudformation/neo4jhacluster.yaml /neo4jhacluster.yaml
-
-RUN apk --update add bash curl py-pip jq \
-    && pip install --upgrade pip awscli
 
 CMD /bin/bash /provision.sh

--- a/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
+++ b/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
@@ -92,7 +92,7 @@ Parameters:
   EbsSnapshot:
     Description: SnapshotId of the EBS Snapshot used to provision the disks.
     Type: String
-    Default: snap-0bb87da873a5238f3
+    Default: snap-0e997dbc63b6da2d0
 
   # Parameters than are used in the user data.
   EtcdToken:

--- a/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
+++ b/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
@@ -92,7 +92,7 @@ Parameters:
   EbsSnapshot:
     Description: SnapshotId of the EBS Snapshot used to provision the disks.
     Type: String
-    Default: snap-0e997dbc63b6da2d0
+    Default: snap-0e9ecacdd229f9d29
 
   # Parameters than are used in the user data.
   EtcdToken:

--- a/upp-neo4j-provisioner/provision.sh
+++ b/upp-neo4j-provisioner/provision.sh
@@ -27,7 +27,7 @@ case "$AWS_DEFAULT_REGION" in
         export SUBNET1="subnet-a32021d5"
         export SUBNET2="subnet-f11956a9"
         export SUBNET3="subnet-00d8db64"
-        export SNAPSHOT="snap-0e997dbc63b6da2d0"
+        export SNAPSHOT="snap-0e9ecacdd229f9d29"
         export AMI=$(curl -s https://coreos.com/dist/aws/aws-stable.json | jq '."eu-west-1".hvm')
         ;;
     us-east-1)
@@ -35,7 +35,7 @@ case "$AWS_DEFAULT_REGION" in
         export SUBNET1="subnet-4158091a"
         export SUBNET2="subnet-64005a49"
         export SUBNET3="subnet-1f383356"
-        export SNAPSHOT="snap-08d4e9ad9f68e3267"
+        export SNAPSHOT="snap-068322a1e3e643d35"
         export AMI=$(curl -s https://coreos.com/dist/aws/aws-stable.json | jq '."us-east-1".hvm')
         ;;
     *)

--- a/upp-neo4j-provisioner/provision.sh
+++ b/upp-neo4j-provisioner/provision.sh
@@ -27,7 +27,7 @@ case "$AWS_DEFAULT_REGION" in
         export SUBNET1="subnet-a32021d5"
         export SUBNET2="subnet-f11956a9"
         export SUBNET3="subnet-00d8db64"
-        export SNAPSHOT="snap-0fbc49cf6de9c245b"
+        export SNAPSHOT="snap-0e997dbc63b6da2d0"
         export AMI=$(curl -s https://coreos.com/dist/aws/aws-stable.json | jq '."eu-west-1".hvm')
         ;;
     us-east-1)
@@ -35,7 +35,7 @@ case "$AWS_DEFAULT_REGION" in
         export SUBNET1="subnet-4158091a"
         export SUBNET2="subnet-64005a49"
         export SUBNET3="subnet-1f383356"
-        export SNAPSHOT="snap-0d6e52d17562fc531"
+        export SNAPSHOT="snap-08d4e9ad9f68e3267"
         export AMI=$(curl -s https://coreos.com/dist/aws/aws-stable.json | jq '."us-east-1".hvm')
         ;;
     *)


### PR DESCRIPTION
The current default snapshot has issues during provisioning - the stale `cluster-health` and lockfile causes the neo4j cluster to not come online cleanly.

This PR updates the snapshot ID to a volume with a skeleton directory structure, and no data. We would expect to want to restore data separately from a source environment anyway, so this shouldn't cause us problems.