### PR TITLE
Adding etcd keys for the publishing cluster

### DIFF
--- a/upp-delivery-provisioner/DEVELOPER_README.md
+++ b/upp-delivery-provisioner/DEVELOPER_README.md
@@ -138,6 +138,10 @@ export AGGREGATE_CONCEPT_QUEUE=
 
 ## Neo4j Fleet Endpoint URL
 export NEO4J_FLEET_ENDPOINT=
+
+## The read url (the non-regional load-balanced url) for the corresponding Publishing cluster and its authoritzation key. i.e. for pre-prod, this should be set to https://pub-pre-prod-up.ft.com
+export PUBLISHING_READ_URL=
+export PUBLISHING_AUTHORIZATION_KEY=
 ```
 
 
@@ -172,6 +176,9 @@ docker run \
     -e "NEO4J_WRITE_URL=$NEO4J_WRITE_URL" \
     -e "AGGREGATE_CONCEPT_BUCKET=$AGGREGATE_CONCEPT_BUCKET" \
     -e "AGGREGATE_CONCEPT_QUEUE=$AGGREGATE_CONCEPT_QUEUE" \
+    -e "NEO4J_FLEET_ENDPOINT=$NEO4J_FLEET_ENDPOINT" \
+    -e "PUBLISHING_READ_URL=$PUBLISHING_READ_URL" \
+    -e "PUBLISHING_AUTHORIZATION_KEY=$PUBLISHING_AUTHORIZATION_KEY" \
     coco/upp-delivery-provisioner:local
 ```
 

--- a/upp-delivery-provisioner/DEVELOPER_README.md
+++ b/upp-delivery-provisioner/DEVELOPER_README.md
@@ -139,7 +139,7 @@ export AGGREGATE_CONCEPT_QUEUE=
 ## Neo4j Fleet Endpoint URL
 export NEO4J_FLEET_ENDPOINT=
 
-## The read url (the non-regional load-balanced url) for the corresponding Publishing cluster and its authoritzation key. i.e. for pre-prod, this should be set to https://pub-pre-prod-up.ft.com
+## The read url (the non-regional load-balanced url) for the corresponding Publishing cluster and its authorization key. i.e. for pre-prod, this should be set to https://pub-pre-prod-up.ft.com
 export PUBLISHING_READ_URL=
 export PUBLISHING_AUTHORIZATION_KEY=
 ```

--- a/upp-delivery-provisioner/README.md
+++ b/upp-delivery-provisioner/README.md
@@ -68,6 +68,8 @@ docker run \
     -e "AGGREGATE_CONCEPT_BUCKET=$AGGREGATE_CONCEPT_BUCKET" \
     -e "AGGREGATE_CONCEPT_QUEUE=$AGGREGATE_CONCEPT_QUEUE" \
     -e "NEO4J_FLEET_ENDPOINT=$NEO4J_FLEET_ENDPOINT" \
+    -e "PUBLISHING_READ_URL=$PUBLISHING_READ_URL" \
+    -e "PUBLISHING_AUTHORIZATION_KEY=$PUBLISHING_AUTHORIZATION_KEY" \
     coco/upp-delivery-provisioner:latest
 
 ## Note - if you require a specific version of the docker image, you can replace 'latest' with 'v1.0.17'

--- a/upp-delivery-provisioner/ansible/userdata/initial_stateless_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/initial_stateless_user_data.yaml
@@ -29,6 +29,8 @@ write_files:
       neo4j_fleet_endpoint={{neo4j_fleet_endpoint}}
       neo4j_read_url={{neo4j_read_url}}
       neo4j_write_url={{neo4j_write_url}}
+      publishing_read_url={{publishing_read_url}}
+      publishing_authorization_key={{publishing_authorization_key}}
       pub_pre_prod_credentials={{pub_pre_prod_credentials}}
       pub_prod_credentials={{pub_prod_credentials}}
       region={{region}}

--- a/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
+++ b/upp-delivery-provisioner/ansible/userdata/stateless_instance_user_data.yaml
@@ -63,6 +63,7 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/elb_name 'coreos-up-${clusterid}'                                                  >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/varnish/htpasswd '${varnish_access_credentials}'                                   >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/kafka-bridge/authorization_key '${bridging_message_queue_proxy_authorization_key}' >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/publishing/authorization_key '${publishing_authorization_key}'                     >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/konstructor/api-key '${konstructor_api_key}'                                       >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/metadata-services/username '${metadata_services_username}'                         >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/_credentials/metadata-services/password '${metadata_services_password}'                         >/dev/null 2>&1 || true;"
@@ -103,6 +104,7 @@ coreos:
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/aggregate-concept-transformer/bucket '${aggregate_concept_bucket}'                       >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/aggregate-concept-transformer/queue_url '${aggregate_concept_queue}'                     >/dev/null 2>&1 || true;"
           ExecStart=/bin/sh -c "etcdctl mk /ft/config/neo4j/fleet_endpoint '${neo4j_fleet_endpoint}'                                           >/dev/null 2>&1 || true;"
+          ExecStart=/bin/sh -c "etcdctl mk /ft/config/publishing/read_url '${publishing_read_url}'                                             >/dev/null 2>&1 || true;"
 
     - name: bootstrap.service
       command: start

--- a/upp-delivery-provisioner/provision.sh
+++ b/upp-delivery-provisioner/provision.sh
@@ -42,5 +42,7 @@ echo $VAULT_PASS > /vault.pass && ansible-playbook -i ~/.ansible_hosts /ansible/
   aggregate_concept_bucket=${AGGREGATE_CONCEPT_BUCKET} \
   aggregate_concept_queue=${AGGREGATE_CONCEPT_QUEUE} \
   neo4j_fleet_endpoint=${NEO4J_FLEET_ENDPOINT} \
-  branch_name=${BRANCH_NAME:=master}" \
+  branch_name=${BRANCH_NAME:=master} \
+  publishing_authorization_key=${PUBLISHING_AUTHORIZATION_KEY} \
+  publishing_read_url=${PUBLISHING_READ_URL}" \
   --vault-password-file=/vault.pass


### PR DESCRIPTION
Adds the following keys to etcd:
* `/ft/_credentials/publishing/authorization_key`
* `/ft/config/publishing/read_url`

This is so the `concept-search-rw` can lookup FT Authors.