### PR TITLE
Fixing escape characters

### DIFF
--- a/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
+++ b/upp-neo4j-provisioner/cloudformation/neo4jhacluster.yaml
@@ -495,7 +495,7 @@ Resources:
               "    content: |\n",
               "      #!/bin/bash\n",
               "      export ENVIRONMENT_TAG=`etcdctl get /ft/config/environment_tag`\n",
-              "      export PS1='\[\033]0;\u@\h:\w\007\]\[\033[01;32m\]\u@\h [$ENVIRONMENT_TAG]\[\033[01;34m\] \w \$\[\033[00m\] '\n",         
+              "      export PS1='\\[\\033]0;\\u@\\h:\\w\\007\\]\\[\\033[01;32m\\]\\u@\\h [$ENVIRONMENT_TAG]\\[\\033[01;34m\\] \\w \\$\\[\\033[00m\\] '\n",         
               ]]
 
   #Application Read Load Balancer


### PR DESCRIPTION
Because doing yaml userdata configuration in CloudFormation templates is an absolute abomination.