### PR TITLE
CircleCI - better Docker tag naming

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
@@ -82,7 +82,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
@@ -127,7 +127,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
@@ -172,7 +172,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
@@ -217,7 +217,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image
@@ -262,7 +262,7 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
-              echo 'export DOCKER_TAG=${CIRCLE_BRANCH}' >> $BASH_ENV
+              echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
             fi
       - run:
           name: Build Docker image

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Automated builds for the provisioner projects are triggered in [CircleCI](https:
 The CircleCI configuration is located [here](https://github.com/Financial-Times/upp-provisioners/blob/master/.circleci/config.yml).
 
 Builds are triggered on commits and pull requests, and must pass to be able to merge into master.
+Note that only provisioners that have CircleCI configuration defined AND have been updated by your commits will be built.  
 
-Only provisioners that have been updated and have CircleCI configuration defined will be built.
+Commits to branches are automatically built, tagged and pushed with the branch name as the Docker image tag.  
+Note that due to tag naming restrictions, branch names containing `/` will only use the second part as the tag.
 
 To enable automated builds for new provisioner projects that contain a Dockerfile:
 


### PR DESCRIPTION
If the branch name contains a `/`, builds fail because Docker tags do not support `/` characters in the tag name.

This change only keeps the second part of a branch name containing a `/`, and uses it as the Docker tag name. 