### PR TITLE
Allow access for content-containers-apps to the SNS topic

### DIFF
--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -34,6 +34,14 @@ Resources:
             Condition:
               ArnLike: 
                 "aws:SourceArn": !Join ["" , ["arn:aws:s3:::", "upp-concept-normalised-store-", !Ref EnvironmentTag]]
+          - Sid: allow-content-container-apps-publish
+            Effect: Allow
+            Principal:
+              AWS: "arn:aws:iam::027104099916:user/content-containers-apps"
+            Action:
+              - SNS:Publish
+              - SNS:GetTopicAttributes
+            Resource: !Ref SNSTopic
       Topics: 
         - !Ref SNSTopic
 


### PR DESCRIPTION
I'm sure we had this in the past, but it seems to have gone missing for some reason.