### PR TITLE
Automatically subscribe secondary region SQS queue to primary SNS topic

### DIFF
--- a/upp-concept-publishing-provisioner/ansible/provision.yml
+++ b/upp-concept-publishing-provisioner/ansible/provision.yml
@@ -25,6 +25,10 @@
     - debug:
         msg: "{{concept_pub_stack_output_1}}"
 
+    - name: Save SNSTopic ARN as a variable
+      set_fact:
+        SNSTopic1ARN: "{{concept_pub_stack_output_1.stack_outputs.SNSTopic1ARN}}"
+
     - name: Create Secondary Concept Publishing stack
       when: "{{is_multi_region|lower}} == true"
       cloudformation:
@@ -37,6 +41,7 @@
         template_parameters:
           EnvironmentTag: "{{environment_tag}}"
           Region: "{{aws_secondary_region}}"
+          SNSTopic1ARN: "{{SNSTopic1ARN}}"
         tags:
           environment: "{{environment_type}}"
           systemCode: "upp"

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
@@ -7,6 +7,9 @@ Parameters:
   Region:
     Type: String
     Default: "Secondary region"
+  SNSTopic1ARN:
+    Type: String
+    Default: "ARN of the primary SNS topic"
 
 Resources:
 
@@ -51,3 +54,12 @@ Resources:
               AWS: "arn:aws:iam::027104099916:user/content-containers-apps"
             Action: "SQS:*"
             Resource: !GetAtt SQSQueue.Arn
+          -
+            Sid: "subscribe-to-primary-sns-queue"
+            Effect: "Allow"
+            Principal:
+              AWS: "*"
+            Action: "SQS:SendMessage"
+            Condition:
+              ArnLike:
+                "aws:SourceArn": !Ref SNSTopic1ARN

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
@@ -38,16 +38,6 @@ Resources:
         Id: ConceptNotificationQueuePolicy
         Statement:
           -
-            Sid: "receive-from-sns"
-            Effect: "Allow"
-            Principal:
-              AWS: "*"
-            Action: "SQS:SendMessage"
-            Resource: !GetAtt SQSQueue.Arn
-            Condition:
-              ArnLike:
-                "aws:SourceArn": !Join ["", ["arn:aws:sns:eu-west-1:027104099916:upp-concept-publishing-", !Ref EnvironmentTag, "-SNSTopic*"]]
-          -
             Sid: "communicate-with-sqs"
             Effect: "Allow"
             Principal:

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
@@ -51,5 +51,5 @@ Resources:
               AWS: "*"
             Action: "SQS:SendMessage"
             Condition:
-              ArnLike:
+              ArnEquals:
                 "aws:SourceArn": !Ref SNSTopic1ARN

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -188,3 +188,8 @@ Resources:
         ScaleOutCooldown: 60
         PredefinedMetricSpecification:
           PredefinedMetricType: DynamoDBWriteCapacityUtilization
+
+Outputs:
+  SNSTopic1ARN:
+    Description: The SNSTopic ARN
+    Value: !Ref SNSTopic

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -77,7 +77,7 @@ Resources:
             Action: "SQS:SendMessage"
             Resource: !GetAtt SQSQueue.Arn
             Condition:
-              ArnLike:
+              ArnEquals:
                 "aws:SourceArn": !Ref SNSTopic
           -
             Sid: "communicate-with-sqs"

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -78,7 +78,7 @@ Resources:
             Resource: !GetAtt SQSQueue.Arn
             Condition:
               ArnLike:
-                "aws:SourceArn": !Join ["", ["arn:aws:sns:eu-west-1:027104099916:upp-concept-publishing-", !Ref EnvironmentTag, "-SNSTopic*"]]
+                "aws:SourceArn": !Ref SNSTopic
           -
             Sid: "communicate-with-sqs"
             Effect: "Allow"


### PR DESCRIPTION
- Create a CF output of the primary SNS topic's ARN
- Save it as a variable in Ansible
- Pass it to secondary template as a parameter
- Update SQS policy to allow access to SNS topic