### PR TITLE
Better Docker image tag support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-delivery-provisioner:
@@ -108,6 +109,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-elasticsearch-provisioner:
@@ -155,6 +157,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-neo4j-provisioner:
@@ -202,6 +205,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-pub-provisioner:
@@ -249,6 +253,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-rds-provisioner:
@@ -296,5 +301,6 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
+            echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
             docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
       - run:
           name: Trigger builds of updated provisioners
           command: |
+            apk -q --no-progress upgrade --no-cache libcurl
             apk -q --no-progress --update add curl
             .circleci/build_provisioners.sh
   upp-concept-publishing-provisioner:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
 jobs:
   trigger-provisioner-builds:
     docker:
-      - image: docker:stable-git
+      - image: docker:stable
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-delivery-provisioner:
     docker:
@@ -108,7 +108,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-elasticsearch-provisioner:
     docker:
@@ -155,7 +155,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-neo4j-provisioner:
     docker:
@@ -202,7 +202,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-pub-provisioner:
     docker:
@@ -249,7 +249,7 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-rds-provisioner:
     docker:
@@ -296,5 +296,5 @@ jobs:
           name: Push Docker image
           command: |
             source ${BASH_ENV}
-            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,10 @@ workflows:
   version: 2
   build:
     jobs:
-      - trigger-provisioner-builds
+      - trigger-provisioner-builds:
+          filters:
+            tags:
+              only: /.*/
 jobs:
   trigger-provisioner-builds:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,9 +32,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
@@ -77,9 +79,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
@@ -122,9 +126,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
@@ -167,9 +173,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
@@ -212,9 +220,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV
@@ -257,9 +267,11 @@ jobs:
             set +o pipefail
             docker load -i /caches/docker-cache.tar | true
       - run:
-          name: Set Docker image tag based on branch
+          name: Set Docker image tag based on branch or git tag
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ] ; then
+            if [ ! -z "${CIRCLE_TAG}" ] ; then
+              echo 'export DOCKER_TAG=${CIRCLE_TAG}' >> $BASH_ENV
+            elif [ "${CIRCLE_BRANCH}" == "master" ] ; then
               echo 'export DOCKER_TAG=latest' >> $BASH_ENV
             else
               echo 'export DOCKER_TAG=$( echo ${CIRCLE_BRANCH} | cut -f 2 -d / )' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Trigger builds of updated provisioners
           command: |
-            apk -q --no-progress --update add curl git
+            apk -q --no-progress --update add curl
             .circleci/build_provisioners.sh
   upp-concept-publishing-provisioner:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
 jobs:
   trigger-provisioner-builds:
     docker:
-      - image: docker:stable
+      - image: docker:stable-git
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Trigger builds of updated provisioners
           command: |
-            apk -q --no-progress --update add curl
+            apk -q --no-progress --update add curl git
             .circleci/build_provisioners.sh
   upp-concept-publishing-provisioner:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-delivery-provisioner:
     docker:
@@ -113,7 +113,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-elasticsearch-provisioner:
     docker:
@@ -161,7 +161,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-neo4j-provisioner:
     docker:
@@ -209,7 +209,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-pub-provisioner:
     docker:
@@ -257,7 +257,7 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
   upp-rds-provisioner:
     docker:
@@ -305,5 +305,5 @@ jobs:
           command: |
             source ${BASH_ENV}
             echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-            docker login -u ${DOCKER_USER} --password-stdin ${DOCKER_PASS}
+            docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
             docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}


### PR DESCRIPTION
Adding support for tagging Docker images with release version numbers.

Let's try and version our updates to provisioners properly again. 🙂 