### PR TITLE
Ignore Promote Errors

### DIFF
--- a/pac-aurora-provisioner/ansible/failover.yml
+++ b/pac-aurora-provisioner/ansible/failover.yml
@@ -28,6 +28,7 @@
       AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
       AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
     register: promote_output
+    ignore_errors: yes
 
   - name: Log promote output
     debug:


### PR DESCRIPTION
Failure to promote the replica (if it's already a master) shouldn't fail the script