### PR TITLE
Update whitelisted CIDRs

### DIFF
--- a/upp-factset-provisioner/cloudformation/loader-security-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/loader-security-group-provisioner.yml
@@ -74,11 +74,6 @@ Resources:
             - Key: description
               Value: "Security group for UPP Factset Loader Instance"
         SecurityGroupIngress:
-            - Description: "OSB + LDNWebPerf"
-              IpProtocol: tcp
-              FromPort: 3306
-              ToPort: 3306
-              CidrIp: 82.136.1.214/32
             - Description: "SSH"
               IpProtocol: tcp
               FromPort: 22
@@ -89,11 +84,6 @@ Resources:
               FromPort: 3306
               ToPort: 3306
               CidrIp: 213.216.148.1/32
-            - Description: "XP - Cluj Office"
-              IpProtocol: tcp
-              FromPort: 3306
-              ToPort: 3306
-              CidrIp: 194.117.242.0/23
             - Description: "EU VPN Client"
               IpProtocol: tcp
               FromPort: 3306
@@ -108,12 +98,12 @@ Resources:
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 94.156.217.228/31
+              CidrIp: 94.156.217.224/29
             - Description: "FT Sofia Office - IP range 2"
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 94.156.217.230/32
+              CidrIp: 212.36.14.64/28
             - Description: "Bracken House FTWLAN"
               IpProtocol: tcp
               FromPort: 3306

--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -78,38 +78,38 @@ Resources:
             - Key: description
               Value: "Security group for UPP Factset RDS store"
         SecurityGroupIngress:
-            # OSB + LDNWebPerf
-            - IpProtocol: tcp
-              FromPort: 3306
-              ToPort: 3306
-              CidrIp: 82.136.1.214/32
-            # SSH
-            - IpProtocol: tcp
+            - Description: "SSH"
+              IpProtocol: tcp
               FromPort: 22
               ToPort: 22
               CidrIp: 82.136.1.214/32
-            # Park Royal
-            - IpProtocol: tcp
+            - Description: "Park Royal"
+              IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
               CidrIp: 213.216.148.1/32
-            # XP - Cluj Office
-            - IpProtocol: tcp
+            - Description: "FT Sofia Office - IP range 1"
+              IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 194.117.242.0/23
-            # EU VPN Client
-            - IpProtocol: tcp
+              CidrIp: 94.156.217.224/29
+            - Description: "FT Sofia Office - IP range 2"
+              IpProtocol: tcp
+              FromPort: 3306
+              ToPort: 3306
+              CidrIp: 212.36.14.64/28
+            - Description: "EU VPN Client"
+              IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
               CidrIp: 62.25.64.1/32
-            # US VPN Client
-            - IpProtocol: tcp
+            - Description: "US VPN Client"
+              IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
               CidrIp: 64.210.200.1/32
-            # Permit access to factset-loader
-            - IpProtocol: tcp
+            - Description: "Permit access to factset-loader"
+              IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
               SourceSecurityGroupId: !Ref LoaderSecurityGroup


### PR DESCRIPTION
1. Update the Sofia office CIDRs 
2. Remove CIDRs to locations that are no longer in use:
    - OSB + LDNWebPerf - Old London office. Currently moving out.
    - XP - Cluj Office - iQuest office. No longer working on FT UPP projects.


Manual steps:
- [ ] Update Stack


More details can be found in the [Jira ticket](https://jira.ft.com/browse/CPH-75)