### PR TITLE
Surface cloudwatch alarms in Heimdall

### DIFF
--- a/pac-aurora-provisioner/ansible/failover-cleanup.yml
+++ b/pac-aurora-provisioner/ansible/failover-cleanup.yml
@@ -106,6 +106,7 @@
       template_parameters:
         EnvironmentName: "{{ cluster_name }}"
         DBClusterIdentifier: "{{ aurora_replica_stack.stack_outputs.DBCluster }}"
+        TagEnvironment: "{{ environment_type }}"
 
   - include: tasks/delete_cname.yml
     vars:

--- a/pac-aurora-provisioner/ansible/provision.yml
+++ b/pac-aurora-provisioner/ansible/provision.yml
@@ -106,6 +106,7 @@
       template_parameters:
         EnvironmentName: "{{ cluster_name }}"
         DBClusterIdentifier: "{{ aurora_eu_stack.stack_outputs.DBCluster }}"
+        TagEnvironment: "{{ environment_type }}"
 
   - include: tasks/create_cname.yml
     vars:
@@ -187,6 +188,7 @@
       template_parameters:
         EnvironmentName: "{{ cluster_name }}"
         DBClusterIdentifier: "{{ aurora_us_stack.stack_outputs.DBCluster }}"
+        TagEnvironment: "{{ environment_type }}"
 
   - include: tasks/create_cname.yml
     vars:

--- a/pac-aurora-provisioner/ansible/vars/content-test.yml
+++ b/pac-aurora-provisioner/ansible/vars/content-test.yml
@@ -2,11 +2,11 @@ regions:
   eu-west-1:
     shortname: eu
     vpc: vpc-f75fb790
-    security_groups: sg-dc82faa5, sg-8bcb5ff2
+    security_groups: sg-05f5615bfa38205ea, sg-8bcb5ff2
     subnets: subnet-932717cb, subnet-c1b94888, subnet-2a1de94d
 
   us-east-1:
     shortname: us
     vpc: vpc-d2bca9b4
-    security_groups: sg-6b79a215, sg-277d4c58
+    security_groups: sg-079aaedb6eff4030f, sg-277d4c58
     subnets: subnet-62bee007, subnet-1520f95d, subnet-dd638cf1

--- a/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
+++ b/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
@@ -12,12 +12,15 @@ Parameters:
 
 Resources:
   # Alarms containing 'critical' will cause dashing to show a critical RED tile.
+  #
+  # Alarms are suffixed by key=value tags so they appear in Heimdall correctly:
+  # https://monitoring-manager.in.ft.com/add-cloudwatch-alarm.
   WriterReplicaLagAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for Replica lag
-      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer'
+      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -38,7 +41,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer'
+      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer system=pac-aurora,environment=p,severity=1'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -59,7 +62,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader'
+      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -80,7 +83,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -101,7 +104,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -122,7 +125,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -143,7 +146,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -164,7 +167,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory'
+      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -183,7 +186,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory'
+      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory system=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:

--- a/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
+++ b/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
@@ -20,7 +20,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for Replica lag
-      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -41,7 +41,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer system=pac-aurora,environment=p,severity=1'
+      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer systemCode=pac-aurora,environment=p,severity=1'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -62,7 +62,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -83,7 +83,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -104,7 +104,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -125,7 +125,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -146,7 +146,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -167,7 +167,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -186,7 +186,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory system=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory systemCode=pac-aurora,environment=p,severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:

--- a/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
+++ b/pac-aurora-provisioner/cloudformation/aurora-cloudwatch.yml
@@ -10,6 +10,15 @@ Parameters:
     Description: An environment name that will be prefixed to resource names
     Type: String
 
+  TagEnvironment:
+      Description: Tag detail for the Environment
+      Type: String
+      AllowedValues:
+          - 't'
+          - 'p'
+          - 'd'
+      Default: t
+
 Resources:
   # Alarms containing 'critical' will cause dashing to show a critical RED tile.
   #
@@ -20,7 +29,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for Replica lag
-      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-replica-lag-writer systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -41,7 +50,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer systemCode=pac-aurora,environment=p,severity=1'
+      AlarmName: !Sub '${EnvironmentName}-critical-engine-uptime-writer systemCode=pac-aurora,environment=${TagEnvironment},severity=1'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -62,7 +71,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for engine uptime, which is a proxy for measuring database availability.
-      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-engine-uptime-reader systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -83,7 +92,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-writer systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -104,7 +113,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for high cpu usage
-      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-utilization-reader systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Dimensions:
@@ -125,7 +134,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-writer systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -146,7 +155,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low CPU Credit Balance. Low balance can limit a cluster's capability to burst above the allotted CPU.
-      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-cpu-credit-balance-reader systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -167,7 +176,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-1-freeable-memory systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:
@@ -186,7 +195,7 @@ Resources:
     Properties:
       ActionsEnabled: False
       AlarmDescription: Monitors for a low amount of available random access memory.
-      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory systemCode=pac-aurora,environment=p,severity=2'
+      AlarmName: !Sub '${EnvironmentName}-2-freeable-memory systemCode=pac-aurora,environment=${TagEnvironment},severity=2'
       Namespace: AWS/RDS
       ComparisonOperator: LessThanOrEqualToThreshold
       Dimensions:


### PR DESCRIPTION
Heimdall supports cloudwatch alarms: https://monitoring-manager.in.ft.com/add-cloudwatch-alarm when the naming follows a convention.

This change allows us to recreate the information shown in Dashing in Heimdall, which brings us a step closer to turning off the former in favour of the latter.

As the stack name remains consistent, the replacement alarms should be created and the old ones deleted on a deploy. The new ones wil still appear in Dashing as it uses the stack name as the prefix for fetching the alarms.

I couldn't find any environment tags being threaded through, if `p` is incorrect please indicate where this is propagated so I can correct them.