### PR TITLE
Feature/uppsf 1059 update loader

### DIFF
--- a/upp-factset-provisioner/README.md
+++ b/upp-factset-provisioner/README.md
@@ -27,6 +27,7 @@ How to run:
 * AWS_ACCOUNT: Account in which to provision RDS; must be either content-test or content-prod
 * AWS_ACCESS_KEY: Access key of the IAM provisioner user
 * AWS_SECRET_ACCESS_KEY: Secret Access key of the IAM provisioner user
+* FT_RESOURCES_SECURITY_GROUP_ID: ID of the FT resources security group in the VPC you are provisioning the cluster (please refer to [FT security groups](https://cloudenablement.in.ft.com/aws/service_guides/ec2/creating_ec2_instances/#security-groups) for more info)
 
 `docker pull coco/upp-factset-provisioner:latest`
 ```
@@ -38,6 +39,7 @@ docker run   \
     -e "AWS_ACCOUNT=$AWS_ACCOUNT" \
     -e "AWS_ACCESS_KEY=$AWS_ACCESS_KEY" \
     -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+    -e "FT_RESOURCES_SECURITY_GROUP_ID=$FT_RESOURCES_SECURITY_GROUP_ID" \
     coco/upp-factset-provisioner:latest /bin/bash provision.sh
 ```
 
@@ -86,6 +88,7 @@ How to run:
 * AWS_ACCESS_KEY: Access key of the IAM provisioner user
 * AWS_SECRET_ACCESS_KEY: Secret Access key of the IAM provisioner user
 * LOADER_SECURITY_GROUP_ID: ID of the security group created when provisioning the whole Factset infrastructure (please refer to step [Provisioning a cluster](#provisioning-a-cluster)) 
+* FT_RESOURCES_SECURITY_GROUP_ID: ID of the FT resources security group in the VPC you are provisioning the ec2 instance (please refer to [FT security groups](https://cloudenablement.in.ft.com/aws/service_guides/ec2/creating_ec2_instances/#security-groups) for more info)
 
 `docker pull coco/upp-factset-provisioner:latest`
 ```
@@ -97,6 +100,7 @@ docker run   \
     -e "AWS_ACCESS_KEY=$AWS_ACCESS_KEY" \
     -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
     -e "LOADER_SECURITY_GROUP_ID=$LOADER_SECURITY_GROUP_ID" \
+    -e "FT_RESOURCES_SECURITY_GROUP_ID=$FT_RESOURCES_SECURITY_GROUP_ID" \
     coco/upp-factset-provisioner:latest /bin/bash provision-loader.sh
 ```
 

--- a/upp-factset-provisioner/README.md
+++ b/upp-factset-provisioner/README.md
@@ -68,3 +68,52 @@ docker run   \
     -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
     coco/upp-factset-provisioner:local /bin/bash decom.sh
 ```
+
+# Provisioning only Factset Loader EC2 instance
+
+Yon can use the following steps in case you need to only provision Factset Loader EC2 instance with non-configured loader application installed, 250GB ebs volume and security group.
+
+How to run:
+
+- Generate credentials for the IAM user `upp-factset-provisioner` in `content-test` aws account for a dev stack or in `content-prod` aws account for a staging/ prod stack.
+
+# Parameters
+
+* ENVIRONMENT_NAME: Used to distinguish between stacks
+* ENVIRONMENT_TAG: Used for AWS resource tagging.
+* VAULT_PASS: Used to read ansible provisioning data, can be found in last pass under **UPP Factset Provisioner**
+* AWS_ACCOUNT: Account in which to provision RDS; must be either content-test or content-prod
+* AWS_ACCESS_KEY: Access key of the IAM provisioner user
+* AWS_SECRET_ACCESS_KEY: Secret Access key of the IAM provisioner user
+* LOADER_SECURITY_GROUP_ID: ID of the security group created when provisioning the whole Factset infrastructure (please refer to step [Provisioning a cluster](#provisioning-a-cluster)) 
+
+`docker pull coco/upp-factset-provisioner:latest`
+```
+docker run   \
+    -e "ENVIRONMENT_NAME=$ENVIRONMENT_NAME" \
+    -e "ENVIRONMENT_TAG=$ENVIRONMENT_TAG" \
+    -e "VAULT_PASS=$VAULT_PASS" \
+    -e "AWS_ACCOUNT=$AWS_ACCOUNT" \
+    -e "AWS_ACCESS_KEY=$AWS_ACCESS_KEY" \
+    -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+    -e "LOADER_SECURITY_GROUP_ID=$LOADER_SECURITY_GROUP_ID" \
+    coco/upp-factset-provisioner:latest /bin/bash provision-loader.sh
+```
+
+## Decommissioning only Factset Loader EC2 instance
+
+How to run:
+
+- Generate credentials for the IAM user `upp-factset-provisioner` in `content-test` aws account for a dev stack or in `content-prod` aws account for a staging/ prod stack.
+- Get the environment variables from the **UPP Factset Provisioner** LastPass note in the **Shared-UPP Credentials & Services Login Details** folder.
+- Run the following docker command
+
+```
+docker run   \
+    -e "ENVIRONMENT_NAME=$ENVIRONMENT_NAME" \
+    -e "VAULT_PASS=$VAULT_PASS" \
+    -e "AWS_ACCOUNT=$AWS_ACCOUNT" \
+    -e "AWS_ACCESS_KEY=$AWS_ACCESS_KEY" \
+    -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+    coco/upp-factset-provisioner:local /bin/bash decom-loader.sh
+```

--- a/upp-factset-provisioner/README.md
+++ b/upp-factset-provisioner/README.md
@@ -47,7 +47,7 @@ docker run   \
 
 ## Manual Setup
 
-There are a few manual steps which need to be run after successful provisioning of a stack which can be found [here](https://docs.google.com/document/d/1GEu0HKSgdq38bPX7RqRyWSftHhwCoMe-iW8nErbqy7A/edit?usp=sharing). The factset loader application is automatically installed on the ec2 instance via user data however the actual setup of needs to be configured on the box itself.
+There are a few manual steps which need to be run after successful provisioning of a stack which can be found [here](https://docs.google.com/document/d/1GEu0HKSgdq38bPX7RqRyWSftHhwCoMe-iW8nErbqy7A/edit?usp=sharing). The installation and actual setup of the factset loader application needs to be done on the box itself.
 
 ## Decommissioning a cluster
 
@@ -103,6 +103,10 @@ docker run   \
     -e "FT_RESOURCES_SECURITY_GROUP_ID=$FT_RESOURCES_SECURITY_GROUP_ID" \
     coco/upp-factset-provisioner:latest /bin/bash provision-loader.sh
 ```
+
+## Manual Setup
+
+There are a few manual steps which need to be run after successful provisioning of the factset loader instance which can be found [here](https://docs.google.com/document/d/1GEu0HKSgdq38bPX7RqRyWSftHhwCoMe-iW8nErbqy7A/edit?usp=sharing). The installation and actual setup of the factset loader application needs to be done on the box itself.
 
 ## Decommissioning only Factset Loader EC2 instance
 

--- a/upp-factset-provisioner/ansible/decom.yml
+++ b/upp-factset-provisioner/ansible/decom.yml
@@ -14,6 +14,8 @@
       stack_name: "upp-factset-loader-{{ environment_name }}"
       region: eu-west-1
       state: "absent"
+    tags:
+      - loader
 
   - name: Remove Factset Rds stack
     cloudformation:

--- a/upp-factset-provisioner/ansible/provision.yml
+++ b/upp-factset-provisioner/ansible/provision.yml
@@ -42,6 +42,8 @@
         EnvironmentName: "{{ environment_name }}"
         EnvironmentTag: "{{ environment_tag }}"
         LoaderSecurityGroup: "{{ LoaderSecurityGroupId }}"
+    tags:
+      - loader
 
   - name: Launch Factset Security and Parameter Group stack
     cloudformation:

--- a/upp-factset-provisioner/ansible/provision.yml
+++ b/upp-factset-provisioner/ansible/provision.yml
@@ -42,6 +42,7 @@
         EnvironmentName: "{{ environment_name }}"
         EnvironmentTag: "{{ environment_tag }}"
         LoaderSecurityGroup: "{{ LoaderSecurityGroupId }}"
+        FTResourcesSecurityGroup: "{{ FTResourcesSecurityGroupId }}"
     tags:
       - loader
 

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -67,9 +67,6 @@ Parameters:
         Type: String
         Default: UPP Factset Aurora Store
 
-Conditions:
-  DevEnv: !Equals [ !Ref EnvironmentTag, 'd' ]
-
 Resources:
   FactsetLoader:
     Type: AWS::EC2::Instance
@@ -97,12 +94,9 @@ Resources:
             Value: !Ref TagIpCode
           - Key: description
             Value: !Ref TagDescription
-          - 'Fn::If':
-              - DevEnv
-              -
-                Key: powercycle
-                Value: '{ "start": "45 4 * * 1-5", "stop": "30 17 * * 1-5" }'
-              - !Ref AWS::NoValue
+          - Key: powercycle
+            Value: '{ "start": "0 5 * * 0-6", "stop": "0 8 * * 0-6" }'
+
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -x

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -108,10 +108,7 @@ Resources:
           #!/bin/bash -x
           /usr/bin/aws s3 cp s3://ft-ce-repository/amazon-ftbase/releases/bootstrap.sh /
           bash /bootstrap.sh -s eng -e ${EnvironmentTag}
-          /usr/bin/aws s3 cp s3://factset-data-loader/FDSLoader-Linux-2.13.2.0.zip /home/ec2-user
           cd /home/ec2-user
           wget https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
           yum -y install mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
-          unzip FDSLoader-Linux.zip -d FactsetLoader
-          chown ec2-user:ec2-user -R FactsetLoader
-          rm FDSLoader-Linux.zip mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
+          rm mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -89,16 +89,14 @@ Resources:
             Value: !Ref TagIpCode
           - Key: description
             Value: !Ref TagDescription
-          - Key: ec2Powercycle
-            Value: '{ "start": "00 4 * * *", "stop": "00 6 * * *" }'
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -x
           /usr/bin/aws s3 cp s3://ft-ce-repository/amazon-ftbase/releases/bootstrap.sh /
           bash /bootstrap.sh -s eng -e ${EnvironmentTag}
+          /usr/bin/aws s3 cp s3://factset-data-loader/FDSLoader-Linux-2.13.2.0.zip /home/ec2-user
           cd /home/ec2-user
           wget https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
-          wget https://www.factset.com/download/datafeedloader/FDSLoader-Linux.zip
           yum -y install mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
           unzip FDSLoader-Linux.zip -d FactsetLoader
           chown ec2-user:ec2-user -R FactsetLoader

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -67,6 +67,9 @@ Parameters:
         Type: String
         Default: UPP Factset Aurora Store
 
+Conditions:
+  DevEnv: !Equals [ !Ref EnvironmentTag, 'd' ]
+
 Resources:
   FactsetLoader:
     Type: AWS::EC2::Instance
@@ -94,6 +97,12 @@ Resources:
             Value: !Ref TagIpCode
           - Key: description
             Value: !Ref TagDescription
+          - 'Fn::If':
+              - DevEnv
+              -
+                Key: powercycle
+                Value: '{ "start": "45 4 * * 1-5", "stop": "30 17 * * 1-5" }'
+              - !Ref AWS::NoValue
       UserData:
         Fn::Base64: !Sub |
           #!/bin/bash -x

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -17,6 +17,11 @@ Parameters:
         Description: Security group id
         Type: String
 
+    FTResourcesSecurityGroup:
+      Description: FT wide resources security group id
+      Type: String
+
+
     DBSubnetIds:
         Description: List of comma separated subnet IDs
         Type: CommaDelimitedList
@@ -74,7 +79,7 @@ Resources:
       IamInstanceProfile: "FT-EC2-Role"
       ImageId: "ami-1a962263"
       InstanceType: !Ref Ec2InstanceType
-      SecurityGroupIds: [ !Ref LoaderSecurityGroup ]
+      SecurityGroupIds: [ !Ref LoaderSecurityGroup, !Ref FTResourcesSecurityGroup ]
       SubnetId: !Select [0, !Ref DBSubnetIds ]
       Tags:
           - Key: Name

--- a/upp-factset-provisioner/sh/decom-loader.sh
+++ b/upp-factset-provisioner/sh/decom-loader.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create Ansible vault credentials
-echo $VAULT_PASS > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass || exit
 
 cd /ansible
 

--- a/upp-factset-provisioner/sh/decom-loader.sh
+++ b/upp-factset-provisioner/sh/decom-loader.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Create Ansible vault credentials
+echo $VAULT_PASS > /ansible/vault.pass
+
+cd /ansible
+
+ansible-playbook --vault-password-file=vault.pass decom.yml --tags "loader" --extra-vars "\
+environment_name=${ENVIRONMENT_NAME} \
+system_code=${SYSTEM_CODE} \
+aws_account=${AWS_ACCOUNT} \
+aws_access_key=${AWS_ACCESS_KEY} \
+aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} "

--- a/upp-factset-provisioner/sh/decom.sh
+++ b/upp-factset-provisioner/sh/decom.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Create Ansible vault credentials
-echo $VAULT_PASS > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass || exit
 
 cd /ansible
 

--- a/upp-factset-provisioner/sh/provision-loader.sh
+++ b/upp-factset-provisioner/sh/provision-loader.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-echo $VAULT_PASS > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass
 
-cd /ansible
+cd /ansible || exit
 
 ansible-playbook --vault-password-file=vault.pass provision.yml --tags "loader" --extra-vars "\
 environment_name=${ENVIRONMENT_NAME} \
 environment_tag=${ENVIRONMENT_TAG} \
 LoaderSecurityGroupId=${LOADER_SECURITY_GROUP_ID} \
+FTResourcesSecurityGroupId=${FT_RESOURCES_SECURITY_GROUP_ID} \
 aws_account=${AWS_ACCOUNT} \
 aws_access_key=${AWS_ACCESS_KEY} \
 aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} "

--- a/upp-factset-provisioner/sh/provision-loader.sh
+++ b/upp-factset-provisioner/sh/provision-loader.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-echo "$VAULT_PASS" > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass || exit
 
-cd /ansible || exit
+cd /ansible
 
 ansible-playbook --vault-password-file=vault.pass provision.yml --tags "loader" --extra-vars "\
 environment_name=${ENVIRONMENT_NAME} \

--- a/upp-factset-provisioner/sh/provision-loader.sh
+++ b/upp-factset-provisioner/sh/provision-loader.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo $VAULT_PASS > /ansible/vault.pass
+
+cd /ansible
+
+ansible-playbook --vault-password-file=vault.pass provision.yml --tags "loader" --extra-vars "\
+environment_name=${ENVIRONMENT_NAME} \
+environment_tag=${ENVIRONMENT_TAG} \
+LoaderSecurityGroupId=${LOADER_SECURITY_GROUP_ID} \
+aws_account=${AWS_ACCOUNT} \
+aws_access_key=${AWS_ACCESS_KEY} \
+aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} "

--- a/upp-factset-provisioner/sh/provision.sh
+++ b/upp-factset-provisioner/sh/provision.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-echo $VAULT_PASS > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass
 
-cd /ansible
+cd /ansible || exit
 
 ansible-playbook --vault-password-file=vault.pass provision.yml --extra-vars "\
 environment_name=${ENVIRONMENT_NAME} \
 environment_tag=${ENVIRONMENT_TAG} \
 db_master_password=${MASTER_PASSWORD} \
+FTResourcesSecurityGroupId = ${FT_RESOURCES_SECURITY_GROUP_ID}\
 aws_account=${AWS_ACCOUNT} \
 aws_access_key=${AWS_ACCESS_KEY} \
 aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} "

--- a/upp-factset-provisioner/sh/provision.sh
+++ b/upp-factset-provisioner/sh/provision.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-echo "$VAULT_PASS" > /ansible/vault.pass
+echo "$VAULT_PASS" > /ansible/vault.pass || exit
 
-cd /ansible || exit
+cd /ansible
 
 ansible-playbook --vault-password-file=vault.pass provision.yml --extra-vars "\
 environment_name=${ENVIRONMENT_NAME} \


### PR DESCRIPTION
Allow Factset loader EC2 instance to be provisioned and decommissioned separate from the whole Factset cluster(rds, param groups, security groups).

Update the provisioning of the whole cluster to accept FT resources security group as parameter.

Update the Factset loader provisioner so that it doesn't install the Factset loader app, that is moved to the manual steps as Factset no longer provide link to download the app with signing in to Factset.