### PR TITLE
Feature/uppsf 1521 ccf es

### DIFF
--- a/upp-elasticsearch-provisioner/README.md
+++ b/upp-elasticsearch-provisioner/README.md
@@ -6,14 +6,12 @@ The AWS ES provisioning process will:
 
  * Create an ElasticSearch Service using the specified CloudFormation template
  * Ensure an S3 bucket exists, and register it to the ES cluster
- * Create or update an appropriate CNAME record for the cluster
  * (Optionally) restore the most recent snapshot in the S3 bucket
 
 The decommissioning process will:
 
  * Take a snapshot of the cluster
  * Delete the cluster
- * Delete the cluster CNAME record
  * (Optionally) delete the S3 bucket for full decommissioning
 
 ## Building the Docker image

--- a/upp-elasticsearch-provisioner/cloudformation/upp-ccf-content.yml
+++ b/upp-elasticsearch-provisioner/cloudformation/upp-ccf-content.yml
@@ -1,0 +1,68 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Template to spin-up an Elasticsearch cluster that contains FT content used by CCF platform
+
+Parameters:
+  EnvironmentType:
+    Description: Environment type (Test or Production).
+    Type: String
+    AllowedValues:
+      - 'd'
+      - 't'
+      - 'p'
+    Default: t
+  ClusterName:
+    Description: The name of the ES cluster
+    Type: String
+  Region:
+    Description: AWS region - only used to generate the domain access policy
+    Type: String
+    AllowedValues:
+      - 'eu-west-1'
+      - 'us-east-1'
+    Default: eu-west-1
+
+Resources:
+  ElasticsearchDomain:
+    Type: "AWS::Elasticsearch::Domain"
+    Properties:
+      DomainName: !Ref ClusterName
+      ElasticsearchVersion: "7.4"
+      ElasticsearchClusterConfig:
+        InstanceCount: "3"
+        InstanceType: "m5.xlarge.elasticsearch"
+        DedicatedMasterEnabled: "true"
+        DedicatedMasterType: "m5.large.elasticsearch"
+        DedicatedMasterCount: "3"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: 0
+        VolumeSize: 30
+        VolumeType: "gp2"
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: "0"
+      AccessPolicies:
+        Version: "2012-10-17"
+        Statement:
+          -
+            Effect: "Allow"
+            Principal:
+              AWS: !Join ["", ["arn:aws:iam::", !Ref 'AWS::AccountId', ":user/content-containers-apps"]]
+            Action: "es:*"
+            Resource: !Join [ "", [ "arn:aws:es:", !Ref Region, ":", !Ref 'AWS::AccountId', ":domain/", !Ref ClusterName, "/*" ] ]
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+      Tags:
+        - Key: environment
+          Value: !Ref EnvironmentType
+        - Key: teamDL
+          Value: "universal.publishing.platform@ft.com"
+        - Key: systemCode
+          Value: "upp"
+        - Key: description
+          Value: !Ref ClusterName
+
+Outputs:
+  ESClusterEndpoint:
+    Description: The ElasticSearch cluster endpoint
+    Value: !GetAtt ElasticsearchDomain.DomainEndpoint


### PR DESCRIPTION
# Description
Add provisioning for content ES needed for the CCF platform

## What

The old schema for provisioning ES cluster is kept and only new cloud formation is added. The ansible scripts are unchanged and the tests show that they are working okay.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-1521
Epic https://financialtimes.atlassian.net/browse/UPPSF-1407

## Anything, in particular, you'd like to highlight to reviewers

It is tested on DEV enviroment and the new cluster is called `upp-ccf-content-dev-eu`.
Please take a look at the instance types. From generation `m5` there is no `medium` size available so I chose `m5.large.elasticsearch`.


## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
