### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/ccf-client-settings-dynamodb-runbook.md
+++ b/runbooks/ccf-client-settings-dynamodb-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # CCF Client Settings DynamoDB
 
 DynamoDB table that contains CCF licences and feeds.
@@ -8,7 +12,7 @@ ccf-client-settings-dynamodb
 
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-provisioners/tree/master/ccf-dynamodb>
+https://github.com/Financial-Times/upp-provisioners/tree/master/ccf-dynamodb
 
 ## Service Tier
 
@@ -17,26 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- dimitar.terziev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-
 
 ## Host Platform
 
@@ -53,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -89,6 +87,14 @@ Manual
 ## Release Details
 
 Follow the steps in the [Copyright Cleared Feed DynamoDB Provisioner](https://github.com/Financial-Times/upp-provisioners/blob/master/ccf-dynamodb/README.md) to provision the DynamoDB table.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/concept-elasticsearch-cluster-runbook.md
+++ b/runbooks/concept-elasticsearch-cluster-runbook.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Concept Elasticsearch Cluster
 
 Elasticsearch cluster used for concept search in UPP hosted in AWS
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners>
-
 ## Code
 
 concept-elasticsearch-cluster
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- dimitar.terziev
-- hristo.georgiev
 
 ## Host Platform
 
@@ -50,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,6 +87,14 @@ Manual
 ## Release Details
 
 A new version of the cluster can be created by provisioning it, please follow the provisioner's <https://github.com/Financial-Times/upp-provisioners/blob/master/upp-elasticsearch-provisioner/README.md>.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/content-fluentd-kinesis-runbook.md
+++ b/runbooks/content-fluentd-kinesis-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Content Fluentd Kinesis Stream
 
 Kinesis stream which will process logs from the Content fluentd instance running within an UPP/PAC Kubernetes cluster.
@@ -18,26 +22,6 @@ Bronze
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- miroslav.gatsanoga
-- ivan.nikolov
-- marina.chompalova
-- mihail.mihaylov
-- boyko.boykov
-- donislav.belev
-- dimitar.terziev
-
 ## Host Platform
 
 AWS
@@ -53,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -89,6 +87,14 @@ Manual
 ## Release Details
 
 Follow the steps in the [Content Fluentd Kinesis Provisioner](https://github.com/Financial-Times/upp-provisioners/blob/master/content-fluentd-kinesis/README.md) to provision it.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/pac-aurora-provisoner-runbook.md
+++ b/runbooks/pac-aurora-provisoner-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - pac-aurora-provisoner
 
 Provisions Aurora RDS for Platform for Annotation Curation (PAC)
@@ -8,7 +12,7 @@ pac-aurora-provisoner
 
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-provisioners/tree/master/pac-aurora-provisioner>
+https://github.com/Financial-Times/upp-provisioners/tree/master/pac-aurora-provisioner
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- hristo.georgiev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -53,6 +40,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -89,6 +90,14 @@ Manual
 ## Release Details
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/pac-aurora-runbook.md
+++ b/runbooks/pac-aurora-runbook.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # PAC Aurora DB
 
 Amazon Aurora MySQL DB cluster used by PAC to persist draft annotations and content.
+
+## Code
+
+pac-aurora
 
 ## Primary URL
 
@@ -14,25 +22,6 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- hristo.georgiev
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- mihail.mihaylov
-- boyko.boykov
-
 ## Host Platform
 
 AWS
@@ -42,10 +31,10 @@ AWS
 The PAC Aurora database is an Amazon Aurora MySQL RDS cluster of 4 database instances spread between two AWS regions - eu-west-1 and us-east-1.
 
 Regional DNS architecture;
-https://www.lucidchart.com/publicSegments/view/b0f16f1b-6393-45ff-91a6-d1da1274e722/image.png
+<https://www.lucidchart.com/publicSegments/view/b0f16f1b-6393-45ff-91a6-d1da1274e722/image.png>
 
 Broader architecture diagram:
-https://www.lucidchart.com/publicSegments/view/22c1656b-6242-4da6-9dfb-f7225c20f38f/image.png
+<https://www.lucidchart.com/publicSegments/view/22c1656b-6242-4da6-9dfb-f7225c20f38f/image.png>
 
 ## Contains Personal Data
 
@@ -54,6 +43,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -71,7 +74,7 @@ Manual
 
 The failover is fully automatic and managed by AWS.
 If someone wants to trigger manually a failover, the guide for that is located here:
-https://github.com/Financial-Times/upp-provisioners/tree/master/pac-aurora-provisioner#automated-failover-between-two-regions
+<https://github.com/Financial-Times/upp-provisioners/tree/master/pac-aurora-provisioner#automated-failover-between-two-regions>
 
 ## Data Recovery Process Type
 
@@ -80,10 +83,10 @@ Manual
 ## Data Recovery Details
 
 The PAC Aurora backup is executed as a daily K8S cron job which performs an AWS snapshot.
-Check https://runbooks.in.ft.com/pac-aurora-backup for more details.
+Check <https://runbooks.in.ft.com/pac-aurora-backup> for more details.
 
 The restoration instructions can be found here:
-https://github.com/Financial-Times/upp-provisioners/blob/master/pac-aurora-provisioner/README.md#provisioning-a-cluster-from-an-existing-database-snapshot
+<https://github.com/Financial-Times/upp-provisioners/blob/master/pac-aurora-provisioner/README.md#provisioning-a-cluster-from-an-existing-database-snapshot>
 
 ## Release Process Type
 
@@ -96,7 +99,15 @@ Manual
 ## Release Details
 
 For release details check:
-https://github.com/Financial-Times/upp-provisioners/blob/master/pac-aurora-provisioner/README.md
+<https://github.com/Financial-Times/upp-provisioners/blob/master/pac-aurora-provisioner/README.md>
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 
@@ -129,13 +140,13 @@ Manually created AWS IAM "pac-content-provisioner" user credentials are used dur
     </p>
 </div>
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 
 Check the AWS console for details, or:
 
-https://sites.google.com/a/ft.com/universal-publishing/ops-guides/pac-aurora-failover
-https://sites.google.com/a/ft.com/universal-publishing/ops-guides/pac-aurora-manual-failover
-https://sites.google.com/a/ft.com/universal-publishing/documentation/pac/aurora-backup-and-restore
-https://sites.google.com/a/ft.com/universal-publishing/documentation/pac/pac-aurora-disaster-recovery-process
+<https://sites.google.com/a/ft.com/universal-publishing/ops-guides/pac-aurora-failover>
+<https://sites.google.com/a/ft.com/universal-publishing/ops-guides/pac-aurora-manual-failover>
+<https://sites.google.com/a/ft.com/universal-publishing/documentation/pac/aurora-backup-and-restore>
+<https://sites.google.com/a/ft.com/universal-publishing/documentation/pac/pac-aurora-disaster-recovery-process>

--- a/runbooks/upp-ccf-content-es-cluster-runbook.md
+++ b/runbooks/upp-ccf-content-es-cluster-runbook.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - CCF Content ElasticSearch Cluster
 
 ElasticSearch cluster for use by the CCF platform. Has content of type articles indexed. It's indexed by ccf-content-rw-elasticsearch and used by combined-content-search.
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners>
-
 ## Code
 
 upp-ccf-content-es-cluster
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- miroslav.gatsanoga
-- dimitar.terziev
-- hristo.georgiev
 
 ## Host Platform
 
@@ -50,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,6 +87,14 @@ Manual
 ## Release Details
 
 A new version of the cluster can be created by provisioning it, please follow the provisioner's <https://github.com/Financial-Times/upp-provisioners/blob/master/upp-elasticsearch-provisioner/README.md>.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-concept-carousel-queue-provisioner.md
+++ b/runbooks/upp-concept-carousel-queue-provisioner.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Concept carousel queue provisioner
 
 Provisioner to provision SQS upp-concept-carousel-queue
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-sqs-provisioner>
-
 ## Code
 
 upp-concept-carousel-queue-provisioner
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-sqs-provisioner
 
 ## Service Tier
 
@@ -17,20 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- donislav.belev
-- boyko.boykov
-- mihail.mihaylov
 
 ## Host Platform
 
@@ -48,9 +38,13 @@ No
 
 No
 
-## Dependencies
+## Can Download Personal Data
 
-- github
+No
+
+## Can Contact Individuals
+
+No
 
 ## Failover Architecture Type
 
@@ -72,6 +66,14 @@ There is no failover available because this is a tool.
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -83,6 +85,14 @@ PartiallyAutomated
 ## Release Details
 
 Standard Git releases flow.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-concept-carousel-queue.md
+++ b/runbooks/upp-concept-carousel-queue.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Concept carousel queue
 
 This is SQS queue for factset-concepts-carousel
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-sqs-provisioner>
-
 ## Code
 
 upp-concept-carousel-queue
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-sqs-provisioner
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- donislav.belev
-- boyko.boykov
-- mihail.mihaylov
 
 ## Host Platform
 
@@ -51,9 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- github
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -75,6 +72,14 @@ There is no failover available because this is a tool.
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -86,6 +91,14 @@ PartiallyAutomated
 ## Release Details
 
 Standard Git releases flow.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-concept-events-queue-runbook.md
+++ b/runbooks/upp-concept-events-queue-runbook.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Concept Events Queue
 
 SQS queue used to propagate concept publishing events.
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-concept-events-pipeline-provisioner>
-
 ## Code
 
 upp-concept-events-queue
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-concept-events-pipeline-provisioner
 
 ## Service Tier
 
@@ -17,25 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- marina.chompalova
-- miroslav.gatsanoga
-- donislav.belev
-- boyko.boykov
-- mihail.mihaylov
 
 ## Host Platform
 
@@ -53,6 +38,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -74,6 +73,14 @@ None
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -85,6 +92,14 @@ PartiallyAutomated
 ## Release Details
 
 Follow the provisioning steps in [AWS Concept Events Pipeline provisioner](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-concept-events-pipeline-provisioner/README.md).
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-concept-publishing-provisioner-runbook.md
+++ b/runbooks/upp-concept-publishing-provisioner-runbook.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Concept Publishing Provisioner
 
 Provisions the normalised concept store (S3 bucket) from the Concept Publishing Pipeline and sets it up with SNS topic and one or more SQS queues.
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-concept-publishing-provisioner>
-
 ## Code
 
 upp-concept-publish-provisioner
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-concept-publishing-provisioner
 
 ## Service Tier
 
@@ -17,26 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- marina.chompalova
-- miroslav.gatsanoga
-- dimitar.terziev
 
 ## Host Platform
 
@@ -54,9 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- github
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -78,6 +72,14 @@ There is no failover available because this is a tool.
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -89,6 +91,14 @@ PartiallyAutomated
 ## Release Details
 
 Standard Git releases flow.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-content-es-runbook.md
+++ b/runbooks/upp-content-es-runbook.md
@@ -1,10 +1,22 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Content Elasticsearch Cluster
 
-Elasticsearch cluster for use by the Content Search API Port service and Content-RW-Elasticsearch service. 
+Elasticsearch cluster for use by the Content Search API Port service and Content-RW-Elasticsearch service.
 
 ## Code
 
 upp-content-es-cluster
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Primary URL
+Enter descriptive text satisfying the following:
+The main url served by the system.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Service Tier
 
@@ -13,26 +25,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- hristo.georgiev
-- robert.marinov
-- elina.kaneva
-- georgi.ivanov
-- tsvetan.dimitrov
-- dimitar.terziev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -49,6 +41,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,6 +92,14 @@ Manual
 
 Manual failover is needed. For more details about the failover process please see: <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster>
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -94,6 +108,18 @@ Manual
 
 Manually created AWS IAM "upp-elasticsearch-provisioner" user credentials are used during provisioning only.
 
+## Monitoring
+
+<p><a href="https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(view~'timeSeries~stacked~false~metrics~(~(~'AWS*2fES~'Nodes~'DomainName~'upp-sapi-v1-prod-eu~'ClientId~'469211898354)~(~'.~'FreeStorageSpace~'.~'.~'.~'.)~(~'.~'JVMMemoryPressure~'.~'.~'.~'.)~(~'.~'ReadIOPS~'.~'.~'.~'.)~(~'.~'WriteLatency~'.~'.~'.~'.)~(~'.~'ReadLatency~'.~'.~'.~'.)~(~'.~'DiskQueueDepth~'.~'.~'.~'.)~(~'.~'ReadThroughput~'.~'.~'.~'.)~(~'.~'CPUUtilization~'.~'.~'.~'.)~(~'.~'WriteIOPS~'.~'.~'.~'.)~(~'.~'SearchableDocuments~'.~'.~'.~'.)~(~'.~'MasterCPUUtilization~'.~'.~'.~'.)~(~'.~'DeletedDocuments~'.~'.~'.~'.)~(~'.~'ClusterUsedSpace~'.~'.~'.~'.)~(~'.~'AutomatedSnapshotFailure~'.~'.~'.~'.)~(~'.~'MasterReachableFromNode~'.~'.~'.~'.)~(~'.~'ClusterStatus.green~'.~'.~'.~'.)~(~'.~'ClusterStatus.yellow~'.~'.~'.~'.)~(~'.~'ClusterStatus.red~'.~'.~'.~'.)~(~'.~'MasterFreeStorageSpace~'.~'.~'.~'.)~(~'.~'MasterJVMMemoryPressure~'.~'.~'.~'.)~(~'.~'ClusterIndexWritesBlocked~'.~'.~'.~'.)~(~'.~'WriteThroughput~'.~'.~'.~'.))~region~'eu-west-1);namespace=AWS/ES;dimensions=ClientId,DomainName" target="_blank">Cloudwatch metrics (please select appropiate region, metrics)</a></p>
+
 ## First Line Troubleshooting
 
 <https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Second Line Troubleshooting
+Enter descriptive text satisfying the following:
+Troubleshooting information for members of the system's support or delivery team.
+
+...or delete this placeholder if not applicable to this system
+-->

--- a/runbooks/upp-es-provisioner-runbook.md
+++ b/runbooks/upp-es-provisioner-runbook.md
@@ -1,14 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP ElasticSearch Provisioner
 
 Provisions ElasticSearch clusters for Universal Publishing Platform.
 
-## Primary URL
-
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-elasticsearch-provisioner>
-
 ## Code
 
 upp-elasticsearch-provisioner
+
+## Primary URL
+
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-elasticsearch-provisioner
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- hristo.georgiev
-- georgi.ivanov
-- elitsa.pavlova
-- miroslav.gatsanoga
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -51,9 +38,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- github
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -75,6 +72,14 @@ There is no failover available because this is a tool.
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -86,6 +91,14 @@ PartiallyAutomated
 ## Release Details
 
 Standard Git releases flow.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-factset-store-runbook.md
+++ b/runbooks/upp-factset-store-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Factset Store
 
 Amazon Aurora MySQL DB cluster used to store Factset data.
@@ -18,25 +22,6 @@ Bronze
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- marina.chompalova
-- miroslav.gatsanoga
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-
 ## Host Platform
 
 AWS
@@ -52,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -88,7 +87,15 @@ Manual
 ## Release Details
 
 For release details check:
-https://github.com/Financial-Times/upp-provisioners/blob/master/upp-factset-provisioner/README.md
+<https://github.com/Financial-Times/upp-provisioners/blob/master/upp-factset-provisioner/README.md>
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 
@@ -105,7 +112,7 @@ NotApplicable
 ## First Line Troubleshooting
 
 Check the Amazon RDS dashboard with the AWS console.
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>>
 
 ## Second Line Troubleshooting
 

--- a/runbooks/upp-jenkins-provisioner-runbook.md
+++ b/runbooks/upp-jenkins-provisioner-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - upp-jenkins-provisioner
 
 Jenkins machines used by UPP
@@ -8,7 +12,7 @@ upp-jenkins-provisioner
 
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-provisioners>
+https://github.com/Financial-Times/upp-provisioners
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- hristo.georgiev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -50,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,6 +87,14 @@ Manual
 ## Release Details
 
 See the [upp-provisioners](https://github.com/Financial-Times/upp-provisioners) repository for details.
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 

--- a/runbooks/upp-jenkins-runbook.md
+++ b/runbooks/upp-jenkins-runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - upp-jenkins
 
 Jenkins machines used by UPP
@@ -8,7 +12,7 @@ upp-jenkins
 
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-provisioners>
+https://github.com/Financial-Times/upp-provisioners
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- dimitar.terziev
-- elitsa.pavlova
-- hristo.georgiev
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -55,6 +42,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -92,6 +93,14 @@ Manual
 
 See the [upp-provisioners](https://github.com/Financial-Times/upp-provisioners) repository for details.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 NotApplicable
@@ -116,12 +125,12 @@ We need to clear the cache so that Jenkins will recover.
 
 Do the following:
 
-1. Login into the Jenkins box using SSH
-2. Login into AWS in the 'ft-tech-content-platform-prod'.
-3. Access this link to find the EC2 instance running Jenkins
-4. ssh to that IP: ssh <your_ft_username>@<jenkins_private_ip>
-Delete the contents of the /var/lib/jenkins/caches folder: rm -rf /var/lib/jenkins/caches/*
-At this point you can either trigger the scanning of the multibranch pipeline manually, or you can wait for Jenkins to do it automatically.
+1.  Login into the Jenkins box using SSH
+2.  Login into AWS in the 'ft-tech-content-platform-prod'.
+3.  Access this link to find the EC2 instance running Jenkins
+4.  ssh to that IP: ssh &lt;your_ft_username>@&lt;jenkins_private_ip>
+    Delete the contents of the /var/lib/jenkins/caches folder: rm -rf /var/lib/jenkins/caches/\*
+    At this point you can either trigger the scanning of the multibranch pipeline manually, or you can wait for Jenkins to do it automatically.
 
 For more please refer to the GitHub repository README for troubleshooting information.
 

--- a/runbooks/upp-ontotext-backup-aurora.md
+++ b/runbooks/upp-ontotext-backup-aurora.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Ontotext Backup Aurora DB
 
 Amazon Aurora PostgreSQL database used to store a backup of the Ontotext automatic suggestions.
@@ -8,7 +12,7 @@ upp-ontotext-backup-aurora
 
 ## Primary URL
 
-<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-ontotext-backup-aurora-provisioner>
+https://github.com/Financial-Times/upp-provisioners/tree/master/upp-ontotext-backup-aurora-provisioner
 
 ## Service Tier
 
@@ -17,23 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- kalin.arsov
-- ivan.nikolov
-- dimitar.terziev
-- mihail.mihaylov
-- boyko.boykov
 
 ## Host Platform
 
@@ -50,6 +37,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -86,6 +87,14 @@ Manual
 ## Release Details
 
 Follow the steps in the [UPP Ontotext Backup RDS Provisioner](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-ontotext-backup-aurora-provisioner/README.md).
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Key Management Process Type
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/upp-provisioners/blob/runbook-no-relationships-2021-03-19/runbooks/upp-concept-carousel-queue.md) file has been automatically regenerated from the Biz Ops data for the **upp-concept-carousel-queue** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-concept-carousel-queue** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-concept-carousel-queue).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
