### PR TITLE
Increase message retention period of concept events SQS

### DIFF
--- a/upp-concept-events-pipeline-provisioner/cloudformation/sqs-single-region.yml
+++ b/upp-concept-events-pipeline-provisioner/cloudformation/sqs-single-region.yml
@@ -32,6 +32,7 @@ Resources:
     Properties:
       QueueName: !Join ["", ["upp-concept-events-", !Ref EnvironmentName]]
       ReceiveMessageWaitTimeSeconds: 20
+      MessageRetentionPeriod: 691200 #8 days
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt SQSConceptEventsDeadletterQueue.Arn
         maxReceiveCount: 5

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
@@ -70,6 +70,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       ReceiveMessageWaitTimeSeconds: 20
+      MessageRetentionPeriod: 691200 #8 days
       RedrivePolicy:
         deadLetterTargetArn : !GetAtt uppconcepteventsdeadletterprod.Arn
         maxReceiveCount : 5
@@ -86,6 +87,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       ReceiveMessageWaitTimeSeconds: 20
+      MessageRetentionPeriod: 691200 #8 days
       RedrivePolicy:
         deadLetterTargetArn : !GetAtt uppconcepteventsdeadletterstaging.Arn
         maxReceiveCount : 5

--- a/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
@@ -53,6 +53,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       ReceiveMessageWaitTimeSeconds: 20
+      MessageRetentionPeriod: 691200 #8 days
       RedrivePolicy:
         deadLetterTargetArn : !GetAtt uppconcepteventsdeadletterdev.Arn
         maxReceiveCount : 5


### PR DESCRIPTION
# Description

## What

Set the `MessageRetentionPeriod` for concept events SQS to 8 days.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2212).

## Anything, in particular, you'd like to highlight to reviewers

The update of the `MessageRetentionPeriod` for concept events SQS will be performed through the AWS console by creating a new change set for the existing CloudFormation stack (already done for Dev and Staging).
The purpose of this PR is to update the provisioners so that they are reflecting the current state of the SQS.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [X] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
