### PR TITLE
Add provisioner for Aurora Postgres, single instance

### DIFF
--- a/.github/runbooks.yml
+++ b/.github/runbooks.yml
@@ -51,3 +51,4 @@ runbooks:
         upp-ontotext-backup-aurora: runbooks/upp-ontotext-backup-aurora.md
         upp-concept-events-queue: runbooks/upp-concept-events-queue-runbook.md
         concept-elasticsearch-cluster: runbooks/concept-elasticsearch-cluster-runbook.md
+        upp-enriched-content-store: runbooks/upp-enriched-content-store-runbook.md

--- a/runbooks/upp-enriched-content-store-runbook.md
+++ b/runbooks/upp-enriched-content-store-runbook.md
@@ -1,0 +1,91 @@
+# UPP Enriched Content Store
+
+Amazon Aurora PostgreSQL database storing FT content in a format close to the content representation in Enriched Content API.
+
+## Code
+
+upp-enriched-content-store
+
+## Primary URL
+
+<https://github.com/Financial-Times/upp-provisioners/tree/master/upp-aurora-postgres-provisioner>
+
+## Service Tier
+
+Bronze
+
+## Lifecycle Stage
+
+Production
+
+## Host Platform
+
+AWS
+
+## Architecture
+
+A single instance Aurora PostgreSQL database is provisioned in the Ireland (eu-west-1) region.
+
+## Contains Personal Data
+
+No
+
+## Contains Sensitive Data
+
+No
+
+## Failover Architecture Type
+
+None
+
+## Failover Process Type
+
+None
+
+## Failback Process Type
+
+None
+
+## Failover Details
+
+None
+
+## Data Recovery Process Type
+
+None
+
+## Data Recovery Details
+
+None
+
+## Release Process Type
+
+Manual
+
+## Rollback Process Type
+
+Manual
+
+## Release Details
+
+Follow the steps in the [UPP Aurora Postgres Provisioner](https://github.com/Financial-Times/upp-provisioners/blob/master/upp-aurora-postgres-provisioner/README.md).
+
+## Key Management Process Type
+
+Manual
+
+## Key Management Details
+
+Manually created AWS IAM "upp-rds-provisioner" user credentials are used during provisioning only.
+
+## Monitoring
+
+Check the RDS dashboard in the AWS console.
+
+## First Line Troubleshooting
+
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
+
+## Second Line Troubleshooting
+
+Please refer to the GitHub repository README for troubleshooting information.

--- a/upp-aurora-postgres-provisioner/Dockerfile
+++ b/upp-aurora-postgres-provisioner/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+COPY scripts/* /usr/local/bin/
+COPY config/ /config/
+
+RUN apt-get update && apt-get install -y \
+    less \
+    zip \
+    curl \
+    wget \
+    jq \
+    vim \
+  && rm -rf /var/lib/apt/lists/* \
+  && get-latest-awscli2 \

--- a/upp-aurora-postgres-provisioner/Dockerfile.files
+++ b/upp-aurora-postgres-provisioner/Dockerfile.files
@@ -1,0 +1,4 @@
+FROM upp-aurora-postgres-rds-provisioner:local
+
+COPY scripts/* /usr/local/bin/
+COPY config/ /config/

--- a/upp-aurora-postgres-provisioner/Makefile
+++ b/upp-aurora-postgres-provisioner/Makefile
@@ -1,0 +1,39 @@
+.DEFAULT_GOAL := rebuild
+IMAGE_NAME=upp-aurora-postgres-rds-provisioner
+
+.PHONY: \
+	rebuild \
+	rebuild-files \
+	deploy \
+	delete
+
+rebuild:
+	docker build \
+		--no-cache \
+		--tag ${IMAGE_NAME}:local \
+		--file Dockerfile .
+
+rebuild-files:
+	docker build \
+		--no-cache \
+		--tag ${IMAGE_NAME}:local \
+		--file Dockerfile.files .
+
+deploy:
+	docker run -it --rm \
+		-e "ENVIRONMENT_NAME=${ENVIRONMENT_NAME}" \
+		-e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+		-e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+		-e "CF_TEMPLATE=${CF_TEMPLATE}" \
+		-e "DB_NAME=${DB_NAME}" \
+		-e "MASTER_USER=uppadmin" \
+		-e "MASTER_PASSWORD=${MASTER_PASSWORD}" \
+		${IMAGE_NAME}:local deploy-rds
+
+delete:
+	docker run -it --rm \
+		-e "ENVIRONMENT_NAME=${ENVIRONMENT_NAME}" \
+		-e "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" \
+		-e "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" \
+		-e "CF_TEMPLATE=${CF_TEMPLATE}" \
+		${IMAGE_NAME}:local delete-rds

--- a/upp-aurora-postgres-provisioner/README.md
+++ b/upp-aurora-postgres-provisioner/README.md
@@ -1,0 +1,60 @@
+# UPP Aurora Postgres RDS Provisioner
+
+Provisions an Amazon RDS Aurora PostgreSQL DB single instance cluster in `eu-west-1` region.
+The database name and intent is determined by the environment variable `CF_TEMPLATE`. The available values are:
+- `enriched-content-rds`
+
+For the available templates, please check the `config/cloudformation` folder.
+
+## Provisioning a new Amazon RDS Aurora PostgreSQL DB cluster
+
+```sh
+cd upp-aurora-postgres-provisioner
+
+make rebuild
+
+# Fill in the AWS credentials created for the "upp-rds-provisioner" user
+export AWS_ACCESS_KEY_ID="xxx"
+export AWS_SECRET_ACCESS_KEY="xxx"
+
+# Fill in the CloudFormation template name that you want to use
+export CF_TEMPLATE="xxx"
+
+# Fill in the database name that you want to use
+export DB_NAME="xxx"
+
+# Specify the DB password
+export MASTER_PASSWORD="xxx"
+
+# Fill in the desired environment (dev, staging, prod)
+export ENVIRONMENT_NAME="dev"
+
+make deploy
+```
+
+If you are actively changing the scripts or AWS CloudFormation templates
+to make the build process faster you can use:
+
+```sh
+make rebuild-files
+```
+
+## Decommissioning the Amazon RDS Aurora PostgreSQL DB cluster
+
+```sh
+cd upp-aurora-postgres-provisioner
+
+make rebuild
+
+# Fill in the AWS credentials created for the "upp-rds-provisioner" user
+export AWS_ACCESS_KEY_ID="xxx"
+export AWS_SECRET_ACCESS_KEY="xxx"
+
+# Fill in the CloudFormation template name that you want to use
+export CF_TEMPLATE="xxx"
+
+# Fill in the desired environment (dev, staging, prod)
+export ENVIRONMENT_NAME="dev"
+
+make delete
+```

--- a/upp-aurora-postgres-provisioner/config/cloudformation/enriched-content-rds.yaml
+++ b/upp-aurora-postgres-provisioner/config/cloudformation/enriched-content-rds.yaml
@@ -1,0 +1,260 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: This template deploys an Aurora cluster with one Postgres instance for the enriched content store.
+
+Metadata:
+    AWS::CloudFormation::Interface:
+        - Label: FT standard tagging
+          Parameters:
+             - EnvironmentTag
+             - TeamDLTag
+             - SystemCodeTag
+
+Parameters:
+    VpcId:
+        Description: The ID of the VPC that will access the cluster.
+        Type: String
+
+    ResourcesSgId:
+        Description: The ID of the resources SG for VPN DB access.
+        Type: String
+
+    ClusterCIDR:
+        Description: The CIDR of the K8s cluster.
+        Type: String
+
+    ClusterCIDRDesc:
+        Description: The description for the CIDR of the K8s cluster.
+        Type: String
+
+    DBSubnetIds:
+        Description: List of comma separated subnet IDs
+        Type: CommaDelimitedList
+
+    DBInstanceId:
+        Description: The ID of the instance to use for the database
+        Type: String
+
+    DBInstanceType:
+        Description: The instance type to use for the database
+        Type: String
+        AllowedValues:
+            - 'db.t3.medium'
+        Default: 'db.t3.medium'
+
+    DBEngineVersion:
+        Description: Select Database Engine Version
+        Type: String
+        Default: '12.4'
+        AllowedValues:
+            - '12.4'
+    DBPort:
+        Description: TCP/IP Port for the Database Instance
+        Type: Number
+        Default: 5432
+        ConstraintDescription: 'Must be in the range [1115-65535]'
+        MinValue: 1115
+        MaxValue: 65535
+    
+    DBName:
+        Description: Database Name
+        Type: String
+        MinLength: '1'
+        MaxLength: '64'
+        AllowedPattern: "^[a-zA-Z]+[0-9a-zA-Z_]*$" 
+        ConstraintDescription: Must start with a letter. Only numbers, letters, and _ accepted. max length 64 characters
+
+    DBMasterUsername:
+        Description: The master username for the database
+        Type: String
+        MinLength: 1
+        MaxLength: 16
+        AllowedPattern: '[a-zA-Z][a-zA-Z0-9]*'
+        ConstraintDescription: must begin with a letter and contain only alphanumeric characters.
+
+    DBMasterPassword:
+        Description: The master password for the database
+        NoEcho: true
+        Type: String
+        MinLength: 10
+        MaxLength: 25
+        AllowedPattern: '[a-zA-Z0-9]*'
+        ConstraintDescription: must contain only alphanumeric characters.
+
+    EnvironmentDesc:
+        Description: An environment name that will be used in the resource descriptions
+        Type: String
+        AllowedValues:
+            - 'Dev'
+            - 'Staging'
+            - 'Prod'
+        Default: 'Dev'
+
+    BaseName:
+        Description: Base name for the resources
+        Type: String
+        Default: UPP Enriched Content RDS
+
+    EnvironmentTag:
+        Description: Tag detail for the Environment; d for team clusters, t for staging and p for production
+        Type: String
+        AllowedValues:
+            - 'd'
+            - 't'
+            - 'p'
+        Default: 'd'
+
+    TeamDLTag:
+        Description: Tag of the TeamDL
+        Type: String
+        AllowedPattern: ^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$
+        ConstraintDescription: There must be a valid email address for the TeamDL
+        Default: universal.publishing.platform@ft.com
+
+    SystemCodeTag:
+        Description: The system code for the environment
+        Type: String
+        Default: upp
+
+Resources:
+    DBSubnetGroup:
+        Type: AWS::RDS::DBSubnetGroup
+        Properties:
+            DBSubnetGroupDescription: !Join ["" , [!Ref BaseName, " Subnet Group ", !Ref EnvironmentDesc]]
+            SubnetIds: !Ref DBSubnetIds
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Subnet Group ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag
+
+    DBSecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+            GroupDescription: !Join ["" , [!Ref BaseName, " Security Group ", !Ref EnvironmentDesc]]
+            VpcId: !Ref VpcId
+            SecurityGroupIngress:
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: 213.86.66.78/32
+                  Description: Bracken House
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: 94.156.217.224/29
+                  Description: FT Sofia Office - IP range 1
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: 212.36.14.64/28
+                  Description: FT Sofia Office - IP range 2
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: 62.25.64.1/32
+                  Description: EU VPN Client
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: 64.210.200.1/32
+                  Description: US VPN Client
+                - IpProtocol: tcp
+                  FromPort: 5432
+                  ToPort: 5432
+                  CidrIp: !Ref ClusterCIDR
+                  Description: !Ref ClusterCIDRDesc
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Subnet Group ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag
+
+    DBCluster:
+        Type: AWS::RDS::DBCluster
+        Properties:
+            Engine: aurora-postgresql
+            EngineVersion: !Ref DBEngineVersion
+            Port: !Ref DBPort
+            DatabaseName: !Ref DBName
+            MasterUsername: !Ref DBMasterUsername
+            MasterUserPassword: !Ref DBMasterPassword
+            DBClusterParameterGroupName: !Ref DBClusterParameterGroup
+            DBSubnetGroupName: !Ref DBSubnetGroup
+            VpcSecurityGroupIds:
+                - !GetAtt
+                    - DBSecurityGroup
+                    - GroupId
+                - !Ref ResourcesSgId
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Cluster ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag
+
+    DBClusterParameterGroup:
+        Type: AWS::RDS::DBClusterParameterGroup
+        Properties:
+            Description: !Join ["" , [!Ref BaseName, " Cluster Parameter Group ", !Ref EnvironmentDesc]]
+            Family: aurora-postgresql12
+            Parameters:
+                rds.force_ssl: 1
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Cluster Parameter Group ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag
+
+    DBPrimaryInstance:
+        Type: AWS::RDS::DBInstance
+        Properties:
+            Engine: aurora-postgresql
+            EngineVersion: !Ref DBEngineVersion
+            DBClusterIdentifier: !Ref DBCluster
+            DBInstanceClass: !Ref DBInstanceType
+            DBInstanceIdentifier: !Ref DBInstanceId
+            DBParameterGroupName: !Ref DBInstanceParameterGroup
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Instance ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag
+
+    DBInstanceParameterGroup:
+        Type: AWS::RDS::DBParameterGroup
+        Properties:
+            Description: !Join ["" , [!Ref BaseName, " Parameter Group ", !Ref EnvironmentDesc]]
+            Family: aurora-postgresql12
+            Parameters:
+                log_statement: "ddl"
+                log_rotation_age: 1440
+                idle_in_transaction_session_timeout: 7200000
+            Tags:
+                - Key: Name
+                  Value: !Join ["" , [!Ref BaseName, " Parameter Group ", !Ref EnvironmentDesc]]
+                - Key: environment
+                  Value: !Ref EnvironmentTag
+                - Key: teamDL
+                  Value: !Ref TeamDLTag
+                - Key: systemCode
+                  Value: !Ref SystemCodeTag

--- a/upp-aurora-postgres-provisioner/config/vars/dev.sh
+++ b/upp-aurora-postgres-provisioner/config/vars/dev.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ENVIRONMENT_DESC="Dev"
+RESOURCES_PREFIX="upp"
+
+AWS_REGION="eu-west-1"
+VPC_ID="vpc-f75fb790"
+CLUSTER_CIDR="10.169.0.0/18"
+CLUSTER_CIDR_DESC="FT-Content-Platform-Test vpc-f75fb790 CIDR"
+RESOURCES_SG_ID="sg-8bcb5ff2"
+RDS_SUBNETS="subnet-020bff57b77ad7438, subnet-0d1ca6b04133a3ad2, subnet-048030b5219e45d9b"
+
+ENVIRONMENT_TAG="d"
+SYSTEM_CODE_TAG="upp"
+TEAM_DL_TAG="universal.publishing.platform@ft.com"
+
+CF_STACK_NAME="${RESOURCES_PREFIX}-${CF_TEMPLATE}-${ENVIRONMENT_NAME}"

--- a/upp-aurora-postgres-provisioner/config/vars/prod.sh
+++ b/upp-aurora-postgres-provisioner/config/vars/prod.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ENVIRONMENT_DESC="Prod"
+RESOURCES_PREFIX="upp"
+
+AWS_REGION="eu-west-1"
+VPC_ID="vpc-ee57bf89"
+CLUSTER_CIDR="10.169.64.0/18"
+CLUSTER_CIDR_DESC="FT-Content-Platform-Prod vpc-ee57bf89 CIDR"
+RESOURCES_SG_ID="sg-39ef7b40"
+RDS_SUBNETS="subnet-024e2e32aefaa01c5, subnet-02526d7213a359f48, subnet-0f2c8a8f1e3db176a"
+
+ENVIRONMENT_TAG="p"
+SYSTEM_CODE_TAG="upp"
+TEAM_DL_TAG="universal.publishing.platform@ft.com"
+
+CF_STACK_NAME="${RESOURCES_PREFIX}-${CF_TEMPLATE}-${ENVIRONMENT_NAME}"

--- a/upp-aurora-postgres-provisioner/config/vars/staging.sh
+++ b/upp-aurora-postgres-provisioner/config/vars/staging.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+set -euo pipefail
+IFS=$'\n\t'
+
+ENVIRONMENT_DESC="Staging"
+RESOURCES_PREFIX="upp"
+
+AWS_REGION="eu-west-1"
+VPC_ID="vpc-ee57bf89"
+CLUSTER_CIDR="10.169.64.0/18"
+CLUSTER_CIDR_DESC="FT-Content-Platform-Prod vpc-ee57bf89 CIDR"
+RESOURCES_SG_ID="sg-39ef7b40"
+RDS_SUBNETS="subnet-024e2e32aefaa01c5, subnet-02526d7213a359f48, subnet-0f2c8a8f1e3db176a"
+
+ENVIRONMENT_TAG="t"
+SYSTEM_CODE_TAG="upp"
+TEAM_DL_TAG="universal.publishing.platform@ft.com"
+
+CF_STACK_NAME="${RESOURCES_PREFIX}-${CF_TEMPLATE}-${ENVIRONMENT_NAME}"

--- a/upp-aurora-postgres-provisioner/scripts/delete-rds
+++ b/upp-aurora-postgres-provisioner/scripts/delete-rds
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+CONFIG_PATH="/config"
+RDS_CONFIG="${CONFIG_PATH}/vars/${ENVIRONMENT_NAME}.sh"
+CF_STACK_TEMPLATE="${CONFIG_PATH}/cloudformation/${CF_TEMPLATE}.yaml"
+
+if [ ! -f "${RDS_CONFIG}" ]; then
+  echo "No configuration for $ENVIRONMENT_NAME exist at ${RDS_CONFIG}"
+  exit 1
+else
+  # shellcheck source=/dev/null
+  source "${RDS_CONFIG}"
+fi
+
+if [ ! -f "${CF_STACK_TEMPLATE}" ]; then
+  echo "No CloudFormation template for ${CF_TEMPLATE} exist at ${RDS_CONFIG}/cloudformation"
+  exit 1
+fi
+
+aws cloudformation delete-stack \
+  --region "${AWS_REGION}" \
+  --stack-name "${CF_STACK_NAME}"
+
+echo "Waiting for the ${CF_STACK_NAME} stack to finish deleting."
+aws cloudformation wait stack-delete-complete \
+  --region "${AWS_REGION}" \
+  --stack-name "${CF_STACK_NAME}"

--- a/upp-aurora-postgres-provisioner/scripts/deploy-rds
+++ b/upp-aurora-postgres-provisioner/scripts/deploy-rds
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+CONFIG_PATH="/config"
+CF_STACK_TEMPLATE="${CONFIG_PATH}/cloudformation/${CF_TEMPLATE}.yaml"
+RDS_CONFIG="${CONFIG_PATH}/vars/${ENVIRONMENT_NAME}.sh"
+
+if [ ! -f "${RDS_CONFIG}" ]; then
+  echo "No configuration for $ENVIRONMENT_NAME exist at ${RDS_CONFIG}"
+  exit 1
+else
+  # shellcheck source=/dev/null
+  source "${RDS_CONFIG}"
+fi
+
+if [ ! -f "${CF_STACK_TEMPLATE}" ]; then
+  echo "No CloudFormation template for ${CF_TEMPLATE} exist at ${RDS_CONFIG}/cloudformation"
+  exit 1
+fi
+
+aws cloudformation deploy \
+  --stack-name "${CF_STACK_NAME}" \
+  --region "${AWS_REGION}" \
+  --template-file "${CF_STACK_TEMPLATE}" \
+  --no-fail-on-empty-changeset \
+  --parameter-overrides \
+  DBInstanceId="${CF_STACK_NAME}" \
+  DBName="${DB_NAME}" \
+  DBMasterUsername="${MASTER_USER}" \
+  DBMasterPassword="${MASTER_PASSWORD}" \
+  DBSubnetIds="${RDS_SUBNETS}" \
+  VpcId="${VPC_ID}" \
+  ClusterCIDR="${CLUSTER_CIDR}" \
+  ClusterCIDRDesc="${CLUSTER_CIDR_DESC}" \
+  ResourcesSgId="${RESOURCES_SG_ID}" \
+  EnvironmentDesc="${ENVIRONMENT_DESC}" \
+  EnvironmentTag="${ENVIRONMENT_TAG}" \
+  SystemCodeTag="${SYSTEM_CODE_TAG}" \
+  TeamDLTag="${TEAM_DL_TAG}"

--- a/upp-aurora-postgres-provisioner/scripts/get-latest-awscli2
+++ b/upp-aurora-postgres-provisioner/scripts/get-latest-awscli2
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+cd /tmp
+
+curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+unzip awscliv2.zip
+./aws/install --update
+
+rm awscliv2.zip
+rm -rf ./aws/


### PR DESCRIPTION
# Description

## What

We need a provisioner for the new enriched content store. I added specific CloudFormation template for the enriched content store. However I kept the rest of the provisioner generic for any Aurora Postgres in  eu-west-1.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-2357

## Anything, in particular, you'd like to highlight to reviewers

_This provisioner is almost the same as the one for the Ontotext Backup DB. We could move the Ontotext Backup CloudFormation template to this provisioner if the approach is approved. We could keep them separated as well having in mind that we may decommission the Ontotext Backup in the next year._

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
