### PR TITLE
Change Concept Normalised Store Access Policy

### DIFF
--- a/upp-concept-publishing-provisioner/cloudformation/databases.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/databases.yml
@@ -20,7 +20,7 @@ Resources:
     Type: "AWS::S3::Bucket"
     Properties:
       BucketName: !Join [ "", ["upp-concept-normalised-store-", !Ref EnvironmentTag]]
-      AccessControl: AuthenticatedRead
+      AccessControl: Private
       NotificationConfiguration:
         TopicConfigurations:
           - Event: "s3:ObjectCreated:*"


### PR DESCRIPTION
# Description

## What

Change Normalised Store S3 bucket ACL to Private. Allowing only for the owner of the bucket to access it. 

## Why

We want to limit who can freely access our concept data to only users with explicit permissions. The previous setup allowed for any AWS account no matter the org to list the contents of the bucket.

## Anything, in particular, you'd like to highlight to reviewers

In the our systems the only service that is using this bucket is `concepts-rw-s3`. This service authorises with `content-container-apps` user, which has `S3-app-policy-managed` allowing it to access any S3 resource.


## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
