### PR TITLE
Add Dead Letter alert for concept publishing SQS

### DIFF
--- a/upp-concept-publishing-provisioner/README.md
+++ b/upp-concept-publishing-provisioner/README.md
@@ -39,6 +39,7 @@ docker run \
     -e "AWS_ACCESS_KEY=$AWS_ACCESS_KEY" \
     -e "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
     -e "SQS_CONCEPT_MAX_DEPTH=$SQS_CONCEPT_MAX_DEPTH" \
+    -e "ALERT_EMAIL=$ALERT_EMAIL
     coco/upp-concept-publishing-provisioner:local /bin/bash provision.sh
 ```
 

--- a/upp-concept-publishing-provisioner/ansible/provision.yml
+++ b/upp-concept-publishing-provisioner/ansible/provision.yml
@@ -13,6 +13,7 @@
           EnvironmentTag: "{{environment_tag}}"
           EnvironmentType: "{{environment_type}}"
           SQSConceptQueueMaxDepth: "{{sqs_concept_max_depth}}"
+          AlertEmail: "{{alert_email}}"
         tags:
           environment: "{{environment_type}}"
           systemCode: "upp"
@@ -60,6 +61,7 @@
           Region: "{{aws_secondary_region}}"
           SNSTopicARN: "{{SNSConceptTopicARN}}"
           SQSConceptQueueMaxDepth: "{{sqs_concept_max_depth}}"
+          AlertEmail: "{{alert_email}}"
         tags:
           environment: "{{environment_type}}"
           systemCode: "upp"

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
@@ -16,6 +16,9 @@ Parameters:
   SQSConceptQueueMaxDepth:
     Type: Number
     Default: 50000
+  AlertEmail:
+    Type: String
+    Default: p2o5v3s3i6a7x0q7@financialtimes.slack.com #upp-concept-load-err channel on Slack
 
 Resources:
   # Create another SQS queue if multi-region is set to true.
@@ -61,7 +64,7 @@ Resources:
   SQSConceptQueueOverflowAlarmSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: p2o5v3s3i6a7x0q7@financialtimes.slack.com #upp-concept-load-err channel on Slack
+      Endpoint: !Ref AlertEmail
       Protocol: email
       TopicArn: !Ref SQSConceptQueueOverflowAlarmTopic
 

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-multi-region.yml
@@ -65,6 +65,28 @@ Resources:
       Protocol: email
       TopicArn: !Ref SQSConceptQueueOverflowAlarmTopic
 
+  SQSConceptQueueDeadletterAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Join [ "", [ "upp-concept-publish-notifications-dead-letter-alarm-", !Ref EnvironmentTag, "-2" ] ]
+      AlarmDescription: !Join [ "", [ "Alarm if concepts dead letter queue contains any messages." ] ]
+      Namespace: "AWS/SQS"
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: { "Fn::GetAtt": [ "SNSDeadLetterQueue", "QueueName" ] }
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+      InsufficientDataActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+      OKActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+
   SQSQueuePolicy:
     Type: "AWS::SQS::QueuePolicy"
     Properties:

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -95,6 +95,28 @@ Resources:
       Protocol: email
       TopicArn: !Ref SQSConceptQueueOverflowAlarmTopic
 
+  SQSConceptQueueDeadletterAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Join [ "", [ "upp-concept-publish-notifications-dead-letter-alarm-", !Ref EnvironmentTag, "-1" ] ]
+      AlarmDescription: !Join [ "", [ "Alarm if concepts dead letter queue contains any messages." ] ]
+      Namespace: "AWS/SQS"
+      MetricName: ApproximateNumberOfMessagesVisible
+      Dimensions:
+        - Name: QueueName
+          Value: { "Fn::GetAtt": [ "SQSDeadLetterConceptQueue", "QueueName" ] }
+      Statistic: Sum
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 0
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+      InsufficientDataActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+      OKActions:
+        - Ref: SQSConceptQueueOverflowAlarmTopic
+
   SQSConceptQueuePolicy:
     Type: "AWS::SQS::QueuePolicy"
     Properties:

--- a/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
+++ b/upp-concept-publishing-provisioner/cloudformation/sns-sqs-cf-single-region.yml
@@ -13,6 +13,9 @@ Parameters:
   SQSConceptQueueMaxDepth:
     Type: Number
     Default: 50000
+  AlertEmail:
+    Type: String
+    Default: p2o5v3s3i6a7x0q7@financialtimes.slack.com #upp-concept-load-err channel on Slack
 
 Resources:
   # Create the topic and the policy.
@@ -91,7 +94,7 @@ Resources:
   SQSConceptQueueOverflowAlarmSubscription:
     Type: AWS::SNS::Subscription
     Properties:
-      Endpoint: p2o5v3s3i6a7x0q7@financialtimes.slack.com #upp-concept-load-err channel on Slack
+      Endpoint: !Ref AlertEmail
       Protocol: email
       TopicArn: !Ref SQSConceptQueueOverflowAlarmTopic
 

--- a/upp-concept-publishing-provisioner/sh/provision.sh
+++ b/upp-concept-publishing-provisioner/sh/provision.sh
@@ -10,4 +10,6 @@ is_multi_region=${IS_MULTI_REGION} \
 aws_secondary_region=${AWS_SECONDARY_REGION} \
 aws_access_key=${AWS_ACCESS_KEY} \
 aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} \
-sqs_concept_max_depth=${SQS_CONCEPT_MAX_DEPTH}"
+sqs_concept_max_depth=${SQS_CONCEPT_MAX_DEPTH} \
+alert_email=${ALERT_EMAIL}"
+


### PR DESCRIPTION
# Description

## What

Create new CloudWatch alert, which  will trigger when there are messages in Concept Publish DeadLetter Queue

## Why

We want to have visibility when some concept fails to be ingested by aggregate-concept-transformer and it is send to the dead letter queue. 

## Anything, in particular, you'd like to highlight to reviewers

I would appreciate any feedback on the trigger, threshold and the check period of the alert.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
