### PR TITLE
Feature/uppsf 4272 ccf upgrade

### DIFF
--- a/upp-elasticsearch-provisioner/Dockerfile
+++ b/upp-elasticsearch-provisioner/Dockerfile
@@ -9,3 +9,4 @@ RUN apk --update add python py-pip ansible bash ca-certificates \
 COPY ansible /ansible
 COPY cloudformation /cloudformation
 COPY sh/* /usr/local/bin/
+COPY vars /vars

--- a/upp-elasticsearch-provisioner/ansible/provision.yml
+++ b/upp-elasticsearch-provisioner/ansible/provision.yml
@@ -5,6 +5,7 @@
 
   vars_files:
     - vault_{{aws_account}}.yml
+    - "{{ env_vars }}"
 
   tasks:
 
@@ -29,9 +30,7 @@
         region: "{{aws_default_region}}"
         template: "/cloudformation/{{cf_template}}.yml"
         template_parameters:
-          EnvironmentType: "{{environment_type}}"
-          ClusterName: "{{cluster_name}}"
-          Region: "{{aws_default_region}}"
+          "{{ template_params }}"
         tags:
           Stack: "{{cluster_name}}"
       register: es_stack_output

--- a/upp-elasticsearch-provisioner/cloudformation/upp-ccf-content-os.yml
+++ b/upp-elasticsearch-provisioner/cloudformation/upp-ccf-content-os.yml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >
+  Template to spin-up an OpenSearch cluster that contains FT content used by CCF platform
+
+Parameters:
+  EnvironmentType:
+    Description: Environment type (Dev,Test or Production).
+    Type: String
+    AllowedValues:
+      - 'd'
+      - 't'
+      - 'p'
+    Default: 'd'
+
+  TeamDLTag:
+    Description: Tag of the TeamDL
+    Type: String
+    AllowedPattern: ^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$
+    ConstraintDescription: There must be a valid email address for the TeamDL
+    Default: 'universal.publishing.platform@ft.com'
+
+  SystemCodeTag:
+    Description: The system code for the environment
+    Type: String
+    Default: 'upp'
+
+  ClusterName:
+    Description: The name of the ES cluster
+    Type: String
+
+  Region:
+    Description: Deprecated - previously used for constructing access policies
+    Type: String
+    Default: eu-west-1
+
+  InstanceType:
+    Description: Instance Type of the cluster nodes
+    Type: String
+    Default: "m6g.xlarge.search"
+
+  MasterType:
+    Description: Dedicated Master Type Type of the cluster nodes
+    Type: String
+    Default: "m6g.large.search"
+
+  StorageSize:
+    Description: Node Volume size in gigabytes
+    Type: Number
+    Default: 30
+
+Resources:
+
+  OpenSearchDomain:
+    Type: "AWS::OpenSearchService::Domain"
+    UpdatePolicy:
+      EnableVersionUpgrade: true
+    Properties:
+      DomainName: !Ref ClusterName
+      EngineVersion: "OpenSearch_1.3"
+      ClusterConfig:
+        InstanceCount: "3"
+        InstanceType: !Ref InstanceType
+        DedicatedMasterEnabled: "true"
+        DedicatedMasterType: !Ref MasterType
+        DedicatedMasterCount: "3"
+      EBSOptions:
+        EBSEnabled: true
+        Iops: 0
+        VolumeSize: !Ref StorageSize
+        VolumeType: "gp2"
+      SnapshotOptions:
+        AutomatedSnapshotStartHour: "0"
+      AdvancedOptions:
+        rest.action.multi.allow_explicit_index: "true"
+      Tags:
+        - Key: environment
+          Value: !Ref EnvironmentType
+        - Key: teamDL
+          Value: !Ref TeamDLTag
+        - Key: systemCode
+          Value: !Ref SystemCodeTag
+        - Key: description
+          Value: !Ref ClusterName
+
+Outputs:
+  ESClusterEndpoint:
+    Description: The OpenSearchDomain cluster endpoint
+    Value: !GetAtt OpenSearchDomain.DomainEndpoint

--- a/upp-elasticsearch-provisioner/sh/provision.sh
+++ b/upp-elasticsearch-provisioner/sh/provision.sh
@@ -9,6 +9,16 @@ if [ ! -f /cloudformation/${CF_TEMPLATE}.yml ] ; then
     exit 1
 fi
 
+env_vars="/vars/${CF_TEMPLATE}-${DELIVERY_CLUSTER}.yml"
+# Validate that ${CF_TEMPLATE}.yml exists
+if [ ! -f ${env_vars} ] ; then
+    echo -e "Error - ${env_vars}.yml doesn't exist.\n"
+    echo -e "Valid \$CF_TEMPLATE values are:"
+    ls /vars/ | sed 's/.yml//g'
+    echo
+    env_vars=""
+fi
+
 # Create Ansible vault credentials
 echo ${VAULT_PASS} > /ansible/vault.pass
 
@@ -22,4 +32,7 @@ environment_type=${ENVIRONMENT_TYPE} \
 restore_es_snapshot=${RESTORE_ES_SNAPSHOT} \
 aws_access_key=${AWS_ACCESS_KEY} \
 aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} \
-aws_account=${AWS_ACCOUNT}"
+aws_account=${AWS_ACCOUNT} \
+env_vars=${env_vars}
+"
+

--- a/upp-elasticsearch-provisioner/sh/provision.sh
+++ b/upp-elasticsearch-provisioner/sh/provision.sh
@@ -1,26 +1,24 @@
 #!/bin/bash
 
 # Validate that ${CF_TEMPLATE}.yml exists
-if [ ! -f /cloudformation/${CF_TEMPLATE}.yml ] ; then
-    echo -e "Error - ${CF_TEMPLATE}.yml doesn't exist.\n"
-    echo -e "Valid \$CF_TEMPLATE values are:"
-    ls /cloudformation/ | sed 's/.yml//g'
-    echo
-    exit 1
+if [ ! -f /cloudformation/${CF_TEMPLATE}.yml ]; then
+  echo -e "Error - ${CF_TEMPLATE}.yml doesn't exist.\n"
+  echo -e "Valid \$CF_TEMPLATE values are:"
+  ls /cloudformation/ | sed 's/.yml//g'
+  echo
+  exit 1
 fi
 
 env_vars="/vars/${CF_TEMPLATE}-${DELIVERY_CLUSTER}.yml"
-# Validate that ${CF_TEMPLATE}.yml exists
-if [ ! -f ${env_vars} ] ; then
-    echo -e "Error - ${env_vars}.yml doesn't exist.\n"
-    echo -e "Valid \$CF_TEMPLATE values are:"
-    ls /vars/ | sed 's/.yml//g'
-    echo
-    env_vars=""
+# Check if there are custom provision properties
+if [ ! -f ${env_vars} ]; then
+  echo -e "Warning - ${env_vars} doesn't exist.\n"
+  echo -e "Using /vars/defaults.yml values."
+  env_vars="/vars/defaults.yml"
 fi
 
 # Create Ansible vault credentials
-echo ${VAULT_PASS} > /ansible/vault.pass
+echo ${VAULT_PASS} >/ansible/vault.pass
 
 cd /ansible
 
@@ -35,4 +33,3 @@ aws_secret_access_key=${AWS_SECRET_ACCESS_KEY} \
 aws_account=${AWS_ACCOUNT} \
 env_vars=${env_vars}
 "
-

--- a/upp-elasticsearch-provisioner/vars/defaults.yml
+++ b/upp-elasticsearch-provisioner/vars/defaults.yml
@@ -1,0 +1,4 @@
+template_params:
+  ClusterName: "{{cluster_name}}"
+  Region: "{{ aws_default_region }}"
+  EnvironmentType: "{{environment_type}}"

--- a/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-dev-eu.yml
+++ b/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-dev-eu.yml
@@ -1,0 +1,8 @@
+template_params:
+  EnvironmentType: "d"
+  TeamDLTag: "universal.publishing.platform@ft.com"
+  SystemCodeTag: "upp"
+  ClusterName: "{{cluster_name}}"
+  InstanceType: "t3.medium.search"
+  MasterType: "t3.medium.search"
+  StorageSize: 30

--- a/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-prod-us.yml
+++ b/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-prod-us.yml
@@ -1,0 +1,8 @@
+template_params:
+  EnvironmentType: "p"
+  TeamDLTag: "universal.publishing.platform@ft.com"
+  SystemCodeTag: "upp"
+  ClusterName: "{{cluster_name}}"
+  InstanceType: "m6g.large.search"
+  MasterType: "m6g.large.search"
+  StorageSize: 30

--- a/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-staging-us.yml
+++ b/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-staging-us.yml
@@ -2,7 +2,7 @@ template_params:
   EnvironmentType: "t"
   TeamDLTag: "universal.publishing.platform@ft.com"
   SystemCodeTag: "upp"
-  ClusterName: "{{cluster_name}}"
+  ClusterName: "upp-ccf-content-os-stage-us" # the default upp-ccf-content-os-staging-us is 29 symbols long. Max domain name length is 28
   InstanceType: "m6g.large.search"
   MasterType: "m6g.large.search"
   StorageSize: 30

--- a/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-staging-us.yml
+++ b/upp-elasticsearch-provisioner/vars/upp-ccf-content-os-staging-us.yml
@@ -1,0 +1,8 @@
+template_params:
+  EnvironmentType: "t"
+  TeamDLTag: "universal.publishing.platform@ft.com"
+  SystemCodeTag: "upp"
+  ClusterName: "{{cluster_name}}"
+  InstanceType: "m6g.large.search"
+  MasterType: "m6g.large.search"
+  StorageSize: 30


### PR DESCRIPTION
# Description

## What

- Added new functionality to the provisioner to be able to specify custom template parameters for different CloudFormation templates
- Add new CloudFormation for CCF Content OpenSearch

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4272

## Anything, in particular, you'd like to highlight to reviewers

### InstanceType

Note that compared to the old provisioner I've made the dev instances a lot smaller. From `m5.large` to `t3.medium`. This is for cost saving purposes.

Staging and prod the nodes were lowered from `m5.xlarge` to `m6g.large`.  I believe they could be even smaller without impacting user experience, but I need to collect more data. 

### Storage 

Lowered the provisioned EBS from 50 to 30 gb. The indexes require around 10 gb with the current setup.

I tried to provision the EBS with `gp3` `VolumeType`, but AWS failed spectacularly with providing any feedback. So I left it with `gp2`.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
