### PR TITLE
use cm-team-dockerhub context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ build-config: &build-config
         command: |
           source ${BASH_ENV}
           echo Pushing coco/${CIRCLE_JOB}:${DOCKER_TAG}
-          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
+          docker login -u ${DOCKER_USER} -p ${DOCKER_ACCESS_TOKEN}
           docker push coco/${CIRCLE_JOB}:${DOCKER_TAG}
 
 # define our CircleCI config here
@@ -59,6 +59,7 @@ workflows:
           filters:
             tags:
               only: /.*/
+          context: cm-team-dockerhub
 jobs:
   trigger-provisioner-builds:
     docker:


### PR DESCRIPTION
# Description

## What

Use cm-team-dockerhub context instead of environment variables for pushing images to dockerhub.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4316)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
