### PR TITLE
Feature/uppsf 4355 sns sqs

### DIFF
--- a/upp-sns-provisioner/cloudformation/sns-prod-eu.yaml
+++ b/upp-sns-provisioner/cloudformation/sns-prod-eu.yaml
@@ -392,3 +392,57 @@ Resources:
       Endpoint: p2o5v3s3i6a7x0q7@financialtimes.slack.com
       Protocol: email
       TopicArn: !Ref SNSuppconceptpublishingprimaryk8sstagingSQSConceptQueueOverflowAlarmTopic
+
+  SNSUPPConceptEventsStaging:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: teamDL
+          Value: !Ref TagTeamDL
+        - Key: SystemCode
+          Value: !Ref TagSystemCode
+        - Key: EnvironmentType
+          Value: !Ref TagEnvironmentType
+      TopicName: upp-concept-events-k8s-staging-SNSTopic
+
+
+  UPPConceptEventsStagingSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-staging"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsStaging
+
+  UPPConceptEventsCECCIStagingSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-cecci-staging"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsStaging
+
+  SNSUPPConceptEventsProd:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: teamDL
+          Value: !Ref TagTeamDL
+        - Key: SystemCode
+          Value: !Ref TagSystemCode
+        - Key: EnvironmentType
+          Value: !Ref TagEnvironmentType
+      TopicName: upp-concept-events-k8s-prod-SNSTopic
+
+
+  UPPConceptEventsProdSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-prod"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsProd
+
+  UPPConceptEventsCECCIProdSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-cecci-prod"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsProd

--- a/upp-sns-provisioner/cloudformation/sns-prod-eu.yaml
+++ b/upp-sns-provisioner/cloudformation/sns-prod-eu.yaml
@@ -401,8 +401,8 @@ Resources:
           Value: !Ref TagTeamDL
         - Key: SystemCode
           Value: !Ref TagSystemCode
-        - Key: EnvironmentType
-          Value: !Ref TagEnvironmentType
+        - Key: environment
+          Value: 't'
       TopicName: upp-concept-events-k8s-staging-SNSTopic
 
 
@@ -428,8 +428,8 @@ Resources:
           Value: !Ref TagTeamDL
         - Key: SystemCode
           Value: !Ref TagSystemCode
-        - Key: EnvironmentType
-          Value: !Ref TagEnvironmentType
+        - Key: environment
+          Value: 'p'
       TopicName: upp-concept-events-k8s-prod-SNSTopic
 
 

--- a/upp-sns-provisioner/cloudformation/sns-prod-us.yaml
+++ b/upp-sns-provisioner/cloudformation/sns-prod-us.yaml
@@ -162,3 +162,41 @@ Resources:
       Endpoint: p2o5v3s3i6a7x0q7@financialtimes.slack.com
       Protocol: email
       TopicArn: !Ref SNSuppconceptpublishingsecondaryk8sstagingSQSConceptQueueOverflowAlarmTopic
+
+  SNSUPPConceptEventsStaging:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: teamDL
+          Value: !Ref TagTeamDL
+        - Key: SystemCode
+          Value: !Ref TagSystemCode
+        - Key: EnvironmentType
+          Value: !Ref TagEnvironmentType
+      TopicName: upp-concept-events-k8s-staging-SNSTopic
+
+  UPPConceptEventsCECCIStagingSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:us-east-1:${AWS::AccountId}:upp-concept-events-cecci-staging"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsStaging
+
+  SNSUPPConceptEventsProd:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: teamDL
+          Value: !Ref TagTeamDL
+        - Key: SystemCode
+          Value: !Ref TagSystemCode
+        - Key: EnvironmentType
+          Value: !Ref TagEnvironmentType
+      TopicName: upp-concept-events-k8s-prod-SNSTopic
+
+  UPPConceptEventsCECCIProdSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:us-east-1:${AWS::AccountId}:upp-concept-events-cecci-prod"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsProd

--- a/upp-sns-provisioner/cloudformation/sns-prod-us.yaml
+++ b/upp-sns-provisioner/cloudformation/sns-prod-us.yaml
@@ -171,8 +171,8 @@ Resources:
           Value: !Ref TagTeamDL
         - Key: SystemCode
           Value: !Ref TagSystemCode
-        - Key: EnvironmentType
-          Value: !Ref TagEnvironmentType
+        - Key: environment
+          Value: 't'
       TopicName: upp-concept-events-k8s-staging-SNSTopic
 
   UPPConceptEventsCECCIStagingSQSSubscription:
@@ -190,8 +190,8 @@ Resources:
           Value: !Ref TagTeamDL
         - Key: SystemCode
           Value: !Ref TagSystemCode
-        - Key: EnvironmentType
-          Value: !Ref TagEnvironmentType
+        - Key: environment
+          Value: 'p'
       TopicName: upp-concept-events-k8s-prod-SNSTopic
 
   UPPConceptEventsCECCIProdSQSSubscription:

--- a/upp-sns-provisioner/cloudformation/sns-testaccount-eu.yaml
+++ b/upp-sns-provisioner/cloudformation/sns-testaccount-eu.yaml
@@ -227,3 +227,30 @@ Resources:
               AWS:SourceOwner: !Ref AWS::AccountId
       Topics:
         - !Ref SNSQueueOverflowAlarmTopic
+
+  SNSUPPConceptEventsDev:
+    Type: AWS::SNS::Topic
+    Properties:
+      Tags:
+        - Key: teamDL
+          Value: !Ref TagTeamDL
+        - Key: SystemCode
+          Value: !Ref TagSystemCode
+        - Key: EnvironmentType
+          Value: !Ref TagEnvironmentType
+      TopicName: upp-concept-events-k8s-SNSTopic
+
+
+  UPPConceptEventsDevSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-dev"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsDev
+
+  UPPConceptEventsCECCIDevSQSSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      Endpoint: !Sub "arn:aws:sqs:eu-west-1:${AWS::AccountId}:upp-concept-events-cecci-dev"
+      Protocol: sqs
+      TopicArn: !Ref SNSUPPConceptEventsDev

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
@@ -158,6 +158,66 @@ Resources:
         - Key: environment
           Value: t
 
+  UPPConceptEventsCECCIStagingDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 0
+      QueueName: "upp-concept-events-cecci-staging-dead-letter"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIStaging:
+    Type: AWS::SQS::Queue
+    Description: Queue used by cm-enriched-content-concept-ingester
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn : !GetAtt UPPConceptEventsCECCIStagingDeadLetter.Arn
+        maxReceiveCount : 5
+      QueueName: "upp-concept-events-cecci-staging"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIProdDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 0
+      QueueName: "upp-concept-events-cecci-prod-dead-letter"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIProd:
+    Type: AWS::SQS::Queue
+    Description: Queue used by cm-enriched-content-concept-ingester
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn : !GetAtt UPPConceptEventsCECCIProdDeadLetter.Arn
+        maxReceiveCount : 5
+      QueueName: "upp-concept-events-cecci-prod"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
   uppconceptcarouselqueuek8sprodPolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:
@@ -279,3 +339,43 @@ Resources:
              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps-staging"
            Action: "SQS:*"
            Resource: !GetAtt uppconceptpublishnotificationsk8sstaging1.Arn
+
+  UPPConceptEventsCECCIStagingPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - Ref: UPPConceptEventsCECCIStaging
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: UppConceptEventsCECCIStagingQueuePolicy
+        Statement:
+          -
+           Sid: "receive-from-sns"
+           Effect: Allow
+           Principal:
+             AWS: "*"
+           Action: "SQS:SendMessage"
+           Resource: !GetAtt UPPConceptEventsCECCIStaging.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-staging-SNSTopic"
+
+  UPPConceptEventsCECCIProdPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - Ref: UPPConceptEventsCECCIProd
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: UppConceptEventsCECCIProdQueuePolicy
+        Statement:
+          -
+           Sid: "receive-from-sns"
+           Effect: Allow
+           Principal:
+             AWS: "*"
+           Action: "SQS:SendMessage"
+           Resource: !GetAtt UPPConceptEventsCECCIProd.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-prod-SNSTopic"

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
@@ -169,7 +169,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 't'
 
   UPPConceptEventsCECCIStaging:
     Type: AWS::SQS::Queue
@@ -186,7 +186,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 't'
 
   UPPConceptEventsCECCIProdDeadLetter:
     Type: AWS::SQS::Queue
@@ -199,7 +199,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 'p'
 
   UPPConceptEventsCECCIProd:
     Type: AWS::SQS::Queue
@@ -216,7 +216,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 'p'
 
   uppconceptcarouselqueuek8sprodPolicy:
     Type: AWS::SQS::QueuePolicy

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-eu.yaml
@@ -262,12 +262,15 @@ Resources:
         Id: ConceptNotificationQueuePolicy
         Statement:
           -
-           Sid: "communicate-with-sqs"
+           Sid: "receive-from-sns"
            Effect: Allow
            Principal:
-             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps"
-           Action: "SQS:*"
+             AWS: "*"
+           Action: "SQS:SendMessage"
            Resource: !GetAtt uppconcepteventsprod.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-prod-SNSTopic"
 
   uppconcepteventsstagingPolicy:
     Type: AWS::SQS::QueuePolicy
@@ -279,12 +282,15 @@ Resources:
         Id: ConceptNotificationQueuePolicy
         Statement:
           -
-           Sid: "communicate-with-sqs"
+           Sid: "receive-from-sns"
            Effect: Allow
            Principal:
-             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps-staging"
-           Action: "SQS:*"
+             AWS: "*"
+           Action: "SQS:SendMessage"
            Resource: !GetAtt uppconcepteventsstaging.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-staging-SNSTopic"
 
   uppconceptpublishnotificationsk8sprod1Policy:
     Type: AWS::SQS::QueuePolicy

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-us.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-us.yaml
@@ -90,7 +90,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 't'
 
   UPPConceptEventsCECCIStaging:
     Type: AWS::SQS::Queue
@@ -107,7 +107,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 't'
 
   UPPConceptEventsCECCIProdDeadLetter:
     Type: AWS::SQS::Queue
@@ -120,7 +120,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 'p'
 
   UPPConceptEventsCECCIProd:
     Type: AWS::SQS::Queue
@@ -137,7 +137,7 @@ Resources:
         - Key: TagTeamDL
           Value: !Ref TagTeamDL
         - Key: environment
-          Value: !Ref TagEnvironmentType
+          Value: 'p'
 
 
   uppconceptpublishnotificationsk8sprod2Policy:

--- a/upp-sqs-provisioner/cloudformation/sqs-prod-us.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-prod-us.yaml
@@ -79,6 +79,66 @@ Resources:
         - Key: environment
           Value: t
 
+  UPPConceptEventsCECCIStagingDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 0
+      QueueName: "upp-concept-events-cecci-staging-dead-letter"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIStaging:
+    Type: AWS::SQS::Queue
+    Description: Queue used by cm-enriched-content-concept-ingester
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn : !GetAtt UPPConceptEventsCECCIStagingDeadLetter.Arn
+        maxReceiveCount : 5
+      QueueName: "upp-concept-events-cecci-staging"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIProdDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 0
+      QueueName: "upp-concept-events-cecci-prod-dead-letter"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIProd:
+    Type: AWS::SQS::Queue
+    Description: Queue used by cm-enriched-content-concept-ingester
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn : !GetAtt UPPConceptEventsCECCIProdDeadLetter.Arn
+        maxReceiveCount : 5
+      QueueName: "upp-concept-events-cecci-prod"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
 
   uppconceptpublishnotificationsk8sprod2Policy:
     Type: AWS::SQS::QueuePolicy
@@ -133,3 +193,43 @@ Resources:
              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps-staging"
            Action: "SQS:*"
            Resource: !GetAtt uppconceptpublishnotificationsk8sstaging2.Arn
+
+  UPPConceptEventsCECCIStagingPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - Ref: UPPConceptEventsCECCIStaging
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: UppConceptEventsCECCIStagingQueuePolicy
+        Statement:
+          -
+           Sid: "receive-from-sns"
+           Effect: Allow
+           Principal:
+             AWS: "*"
+           Action: "SQS:SendMessage"
+           Resource: !GetAtt UPPConceptEventsCECCIStaging.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:us-east-1:${AWS::AccountId}:upp-concept-events-k8s-staging-SNSTopic"
+
+  UPPConceptEventsCECCIProdPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - Ref: UPPConceptEventsCECCIProd
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: UppConceptEventsCECCIProdQueuePolicy
+        Statement:
+          -
+           Sid: "receive-from-sns"
+           Effect: Allow
+           Principal:
+             AWS: "*"
+           Action: "SQS:SendMessage"
+           Resource: !GetAtt UPPConceptEventsCECCIProd.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:us-east-1:${AWS::AccountId}:upp-concept-events-k8s-prod-SNSTopic"

--- a/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
@@ -164,12 +164,15 @@ Resources:
         Id: ConceptNotificationQueuePolicy
         Statement:
           -
-           Sid: "communicate-with-sqs"
+           Sid: "receive-from-sns"
            Effect: Allow
            Principal:
-             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps"
-           Action: "SQS:*"
+             AWS: "*"
+           Action: "SQS:SendMessage"
            Resource: !GetAtt uppconcepteventsdev.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-SNSTopic"
   uppconceptcarouselqueuek8sPolicy:
     Type: AWS::SQS::QueuePolicy
     Properties:

--- a/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
+++ b/upp-sqs-provisioner/cloudformation/sqs-testaccount-eu.yaml
@@ -97,6 +97,36 @@ Resources:
         - Key: environment
           Value: !Ref TagEnvironmentType
 
+  UPPConceptEventsCECCIDevDeadLetter:
+    Type: AWS::SQS::Queue
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 0
+      QueueName: "upp-concept-events-cecci-dev-dead-letter"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
+  UPPConceptEventsCECCIDev:
+    Type: AWS::SQS::Queue
+    Description: Queue used by cm-enriched-content-concept-ingester
+    Properties:
+      ReceiveMessageWaitTimeSeconds: 20
+      RedrivePolicy:
+        deadLetterTargetArn : !GetAtt UPPConceptEventsCECCIDevDeadLetter.Arn
+        maxReceiveCount : 5
+      QueueName: "upp-concept-events-cecci-dev"
+      Tags:
+        - Key: systemCode
+          Value: !Ref TagSystemCode
+        - Key: TagTeamDL
+          Value: !Ref TagTeamDL
+        - Key: environment
+          Value: !Ref TagEnvironmentType
+
 
   uppconceptpublishnotificationsk8s1Policy:
     Type: AWS::SQS::QueuePolicy
@@ -156,3 +186,23 @@ Resources:
               AWS: !Sub "arn:aws:iam::${AWS::AccountId}:user/content-containers-apps"
             Action: "SQS:*"
             Resource: !GetAtt uppconceptcarouselqueuek8s.Arn
+
+  UPPConceptEventsCECCIDevPolicy:
+    Type: AWS::SQS::QueuePolicy
+    Properties:
+      Queues:
+        - Ref: UPPConceptEventsCECCIDev
+      PolicyDocument:
+        Version: "2012-10-17"
+        Id: UppConceptEventsCECCIDevQueuePolicy
+        Statement:
+          -
+           Sid: "receive-from-sns"
+           Effect: Allow
+           Principal:
+             AWS: "*"
+           Action: "SQS:SendMessage"
+           Resource: !GetAtt UPPConceptEventsCECCIDev.Arn
+           Condition:
+             ArnLike:
+               "aws:SourceArn": !Sub "arn:aws:sns:eu-west-1:${AWS::AccountId}:upp-concept-events-k8s-SNSTopic"


### PR DESCRIPTION
# Description

Creating new SNS topic and a SQS. 

We want to replace the SQS used by `aggregate-concept-transformer` with SNS so that more than one service can consume the concept update events generated by AGGY. 

We'll keep the already existing `upp-concept-events` SQS because it is used by `concept-events-notifications` service and we are creating an additional SQS which will be used by the `cm-enriched-content-concept-ingester`.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-4355)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
