### PR TITLE
Update ontotext backup provisioner

### DIFF
--- a/upp-ontotext-backup-aurora-provisioner/config/cloudformation/ontotext-backup-rds.yaml
+++ b/upp-ontotext-backup-aurora-provisioner/config/cloudformation/ontotext-backup-rds.yaml
@@ -47,15 +47,15 @@ Parameters:
         Description: The instance type to use for the database
         Type: String
         AllowedValues:
-            - 'db.t3.medium'
-        Default: 'db.t3.medium'
+            - 'db.r6g.large'
+        Default: 'db.r6g.large'
 
     DBEngineVersion:
         Description: Select Database Engine Version
         Type: String
-        Default: '11.13'
+        Default: '12.15'
         AllowedValues:
-            - '11.13'
+            - '12.15'
     DBPort:
         Description: TCP/IP Port for the Database Instance
         Type: Number


### PR DESCRIPTION
# Description

## What

- change the ontotext backup postgresql version to 12.15
- change the ontotext backup instance from burst one db.t3 to static one db.r6g.

## Why

The PostgreSQL upgrade was because version 11 was deprecated by AWS.
The instance was upgraded because some clients were overloading the smaller instance and the burst was costing more than the static instance.

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
