### PR TITLE
Update ODBC connector version for MySQL 8

### DIFF
--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -133,6 +133,6 @@ Resources:
           /usr/bin/aws s3 cp s3://amazon-ftbase/amazon-ftbase2/releases/bootstrap.sh /
           bash /bootstrap.sh -s eng -e ${EnvironmentTag} --disable-yum-security-update-schedule
           cd /home/ec2-user
-          wget https://dev.mysql.com/get/Downloads/Connector-ODBC/5.3/mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
+          wget https://dev.mysql.com/get/Downloads/Connector-ODBC/9.0/mysql-connector-odbc-9.0.0-1.el7.x86_64.rpm
           yum -y install mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
           rm mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm


### PR DESCRIPTION
# Description
upp-factset-provisioner: change ec2 loader to use MySQL Connector/ODBC 9 which supports MySQL 8

## What

With the end of support for MySQL 5.7 we are upgrading  upp-factset-rds to use MySQL 8, thus the need to upgrade the ODBC connector driver to support MySQL 8

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5546)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
