### PR TITLE
update factset loader to use Amazon Linux 2023 / AL3 instead of AL2

### DIFF
--- a/upp-factset-provisioner/ansible/provision.yml
+++ b/upp-factset-provisioner/ansible/provision.yml
@@ -7,6 +7,8 @@
   - name: Load account-specific vault variables
     include_vars:
       file: "vault_{{ aws_account }}.yml"
+    tags:
+      - always
 
   - name: Launch Factset Loader Security Group stack
     cloudformation:

--- a/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/ec2-loader-provisioner.yml
@@ -77,7 +77,7 @@ Resources:
             VolumeType: "gp2"
             VolumeSize: 250
       IamInstanceProfile: "FT-EC2-Role"
-      ImageId: "ami-08a2aed6e0a6f9c7d"
+      ImageId: "ami-0c13c2049f369d641"
       InstanceType: !Ref Ec2InstanceType
       SecurityGroupIds: [ !Ref LoaderSecurityGroup, !Ref FTResourcesSecurityGroup ]
       SubnetId: !Select [0, !Ref DBSubnetIds ]
@@ -133,6 +133,9 @@ Resources:
           /usr/bin/aws s3 cp s3://amazon-ftbase/amazon-ftbase2/releases/bootstrap.sh /
           bash /bootstrap.sh -s eng -e ${EnvironmentTag} --disable-yum-security-update-schedule
           cd /home/ec2-user
-          wget https://dev.mysql.com/get/Downloads/Connector-ODBC/9.0/mysql-connector-odbc-9.0.0-1.el7.x86_64.rpm
-          yum -y install mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
-          rm mysql-connector-odbc-5.3.9-1.el7.x86_64.rpm
+          dnf -y install unixODBC openldap-compat libxcrypt-compat libnsl
+          sudo dnf install -y \
+            https://repo.mysql.com/yum/mysql-connectors-community/el/9/x86_64/mysql-connector-odbc-9.0.0-1.el9.x86_64.rpm
+          sudo dnf install -y cronie
+          sudo systemctl enable --now crond
+          command -v odbcinst


### PR DESCRIPTION
# Description

## What

Update the factset provisioner to provision Amazon Linux 2023 instead of AL2 due to cyber essentials.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-7001)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the test_  
_I am not quite sure how this bit works_  
_Is there a better library for doing x_  

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
