### PR TITLE
Restrict FactSet RDS security-group ingress

### DIFF
--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -49,9 +49,11 @@ Parameters:
 Mappings:
     EnvironmentCidrs:
         dev:
+            Name: Test
             EKS: 10.169.0.0/18
             VPC: 10.172.32.0/21
         prod:
+            Name: Prod
             EKS: 10.168.64.0/18
             VPC: 10.172.40.0/21
 
@@ -74,12 +76,12 @@ Resources:
             - Key: description
               Value: "Security group for UPP Factset RDS store"
         SecurityGroupIngress:
-            - Description: "Content Platform EKS CIDR"
+            - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " EKS"]]
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
               CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, EKS]
-            - Description: "Content Platform VPC CIDR"
+            - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " VPC"]]
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306

--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -50,11 +50,13 @@ Mappings:
     EnvironmentCidrs:
         dev:
             Name: Test
-            EKS: 10.169.0.0/18
+            EUEKS: 10.169.0.0/18
+            USEKS: 10.168.0.0/18
             VPC: 10.172.32.0/21
         prod:
             Name: Prod
-            EKS: 10.168.64.0/18
+            EUEKS: 10.169.64.0/18
+            USEKS: 10.168.64.0/18
             VPC: 10.172.40.0/21
 
 Resources:
@@ -76,11 +78,16 @@ Resources:
             - Key: description
               Value: "Security group for UPP Factset RDS store"
         SecurityGroupIngress:
-            - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " EKS"]]
+            - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " EU EKS"]]
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, EKS]
+              CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, EUEKS]
+            - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " US EKS"]]
+              IpProtocol: tcp
+              FromPort: 3306
+              ToPort: 3306
+              CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, USEKS]
             - Description: !Join ["", ["DB access from Content Platform ", !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, Name], " VPC"]]
               IpProtocol: tcp
               FromPort: 3306

--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -4,13 +4,13 @@ Description: This template deploys a security group and a parameter group to be 
 
 Metadata:
     AWS::CloudFormation::Interface:
-        - Label: FT standard tagging
-          Parameters:
-             - TagEnvironment
-             - TagTeamDL
-             - TagSystemCode
-             - TagIpCode
-             - TagDescription
+        ParameterGroups:
+            - Label:
+                  default: FT standard tagging
+              Parameters:
+                  - TagTeamDL
+                  - TagSystemCode
+                  - TagIpCode
 
 Parameters:
     DBVPC:
@@ -51,11 +51,6 @@ Parameters:
         Type: String
         AllowedPattern: '[P][0-9]*'
         Default: P196
-
-    TagDescription:
-        Description: Tag detail for the describing the instance
-        Type: String
-        Default: UPP Factset RDS Group
 
 Mappings:
     EnvironmentCidrs:

--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -8,9 +8,9 @@ Metadata:
             - Label:
                   default: FT standard tagging
               Parameters:
+                  - EnvironmentTag
                   - TagTeamDL
                   - TagSystemCode
-                  - TagIpCode
 
 Parameters:
     DBVPC:
@@ -46,12 +46,6 @@ Parameters:
         Type: String
         Default: upp
 
-    TagIpCode:
-        Description: The environment ipCode
-        Type: String
-        AllowedPattern: '[P][0-9]*'
-        Default: P196
-
 Mappings:
     EnvironmentCidrs:
         dev:
@@ -77,8 +71,6 @@ Resources:
               Value: !Ref TagTeamDL
             - Key: systemCode
               Value: !Ref TagSystemCode
-            - Key: ipCode
-              Value: !Ref TagIpCode
             - Key: description
               Value: "Security group for UPP Factset RDS store"
         SecurityGroupIngress:
@@ -124,8 +116,6 @@ Resources:
               Value: !Ref TagTeamDL
             - Key: systemCode
               Value: !Ref TagSystemCode
-            - Key: ipCode
-              Value: !Ref TagIpCode
             - Key: description
               Value: 'Parameter Group for Factset RDS Store'
 

--- a/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
+++ b/upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml
@@ -57,6 +57,15 @@ Parameters:
         Type: String
         Default: UPP Factset RDS Group
 
+Mappings:
+    EnvironmentCidrs:
+        dev:
+            EKS: 10.169.0.0/18
+            VPC: 10.172.32.0/21
+        prod:
+            EKS: 10.168.64.0/18
+            VPC: 10.172.40.0/21
+
 Resources:
     FactsetSecurityGroup:
       Type: AWS::EC2::SecurityGroup
@@ -78,36 +87,26 @@ Resources:
             - Key: description
               Value: "Security group for UPP Factset RDS store"
         SecurityGroupIngress:
-            - Description: "SSH"
-              IpProtocol: tcp
-              FromPort: 22
-              ToPort: 22
-              CidrIp: 82.136.1.214/32
-            - Description: "Park Royal"
+            - Description: "Content Platform EKS CIDR"
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 213.216.148.1/32
-            - Description: "FT Sofia Office - IP range 1"
+              CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, EKS]
+            - Description: "Content Platform VPC CIDR"
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 94.156.217.224/29
-            - Description: "FT Sofia Office - IP range 2"
+              CidrIp: !FindInMap [EnvironmentCidrs, !Ref EnvironmentName, VPC]
+            - Description: "AWS Client VPN, eu-west-1"
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 212.36.14.64/28
-            - Description: "EU VPN Client"
+              CidrIp: 10.165.0.0/24
+            - Description: "AWS Client VPN, us-east-1"
               IpProtocol: tcp
               FromPort: 3306
               ToPort: 3306
-              CidrIp: 62.25.64.1/32
-            - Description: "US VPN Client"
-              IpProtocol: tcp
-              FromPort: 3306
-              ToPort: 3306
-              CidrIp: 64.210.200.1/32
+              CidrIp: 10.166.0.0/24
             - Description: "Permit access to factset-loader"
               IpProtocol: tcp
               FromPort: 3306


### PR DESCRIPTION
# Description

## What

Update the FactSet RDS security-group CloudFormation template to allow only the private networks required by the Content Platform environments and AWS Client VPNs. The loader security-group reference is retained because Ansible creates the loader SG first and passes its ID into this RDS security-group stack.

The template now uses `dev` and `prod` mappings for the Content Platform EKS and original VPC CIDRs, includes the UK and US Client VPN CIDRs, removes obsolete public/SSH ingress, removes the stale `10.178.224.0/21` range, removes the legacy `ipCode` tag, and presents the actual `EnvironmentTag` parameter in the standard tagging group.

## Why

The Aurora DB instances are configured with `PubliclyAccessible: false` and have no public IPv4 address. Public office, public VPN, and SSH ingress rules are not required for direct access to these RDS instances.

## Anything, in particular, you'd like to highlight to reviewers

The `dev` mapping represents the Content Platform Test VPC. The `prod` mapping represents the Content Platform Prod VPC. The US Client VPN CIDR assumes an existing routed and authorised path to the RDS VPCs.

## Scope and particulars of this PR (Please tick all that apply)

- [x] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)

## Validation

`cfn-lint upp-factset-provisioner/cloudformation/security-and-parameter-group-provisioner.yml` passes. `git diff --check` passes.